### PR TITLE
Remove new discovery flags upon codex scan

### DIFF
--- a/SrvSurvey/plotters/PlotBioSystem.cs
+++ b/SrvSurvey/plotters/PlotBioSystem.cs
@@ -215,8 +215,8 @@ namespace SrvSurvey.plotters
 
                     // do we already know if this is a first discovery?
                     string? discoveryPrefix = null;
-                    if (organism.isCmdrFirst) discoveryPrefix = "⚑";
-                    else if (organism.isNewEntry) discoveryPrefix = "⚐";
+                    //if (organism.isCmdrFirst) discoveryPrefix = "⚑";
+                    //else if (organism.isNewEntry) discoveryPrefix = "⚐";
 
                     dty = (int)dty;
 
@@ -623,8 +623,7 @@ namespace SrvSurvey.plotters
                     // genus was scanned
                     if (org.entryId > 0)
                     {
-                        if (org.isFirst) volCol = VolColor.Gold;
-                        else if (!org.analyzed && Game.activeGame?.cmdrCodex.isDiscovered(org.entryId) == false) volCol = VolColor.Gold;
+                        if (!org.analyzed && Game.activeGame?.cmdrCodex.isDiscovered(org.entryId) == false) volCol = VolColor.Gold;
                         var min = body.getBioRewardForGenus(org, true);
                         var max = body.getBioRewardForGenus(org, false);
                         VolumeBar.render(g, x, y, volCol, min, max, false);


### PR DESCRIPTION
SRV Survey will display a solid or hollow flag and color a biological signal gold if it is the commander's first time seeing it, or the first time seeing it for a region. This flag and coloration remains there, even after the commander has scanned the biological signal and added it to their codex.

This update would change it so that the biological signal returns to normal colors and removes the flag icon once the signal has been scanned. This will allow players to more easily keep track of exactly what they still need to discover within a system.

Before scans:
![image](https://github.com/user-attachments/assets/1e6bc684-9194-4ca3-bc9a-b85ce437eff0)

After fully scanning Fonticulua and partially scanning Bacterium:
![image](https://github.com/user-attachments/assets/ec13bed0-bba8-4690-95b0-55c6170e5246)
![image](https://github.com/user-attachments/assets/bfd696ee-1151-451c-9dbe-d8a0ad2f250d)

This does remove a bit of the "caching" functionality that was present in the `isCmdrFirst` and `isNewEntry` properties. I'm not sure if this was a performance optimization or not, so I'm open to suggestions if you think these changes might cause problems.
