### PR TITLE
fix: handle null stations in Spansh API response

### DIFF
--- a/SrvSurvey/Program.cs
+++ b/SrvSurvey/Program.cs
@@ -1,4 +1,6 @@
+using Newtonsoft.Json;
 using SrvSurvey.game;
+using SrvSurvey.net;
 using SrvSurvey.plotters;
 using System.ComponentModel;
 using System.Diagnostics;
@@ -51,6 +53,13 @@ namespace SrvSurvey
 
             try
             {
+                // Configure JSON.NET to ignore null values for list properties,
+                // so lists keep their initialized empty value instead of being set to null
+                JsonConvert.DefaultSettings = () => new JsonSerializerSettings
+                {
+                    ContractResolver = new NullListContractResolver()
+                };
+
                 if (!string.IsNullOrEmpty(Game.settings.lang))
                 {
                     var culture = System.Globalization.CultureInfo.CreateSpecificCulture(Game.settings.lang);

--- a/SrvSurvey/net/Canonn.cs
+++ b/SrvSurvey/net/Canonn.cs
@@ -2098,7 +2098,7 @@ namespace SrvSurvey.canonn
 
     internal class CanonnBodyBioStats
     {
-        public List<CanonnBodyBioStatsBody> bodies;
+        public List<CanonnBodyBioStatsBody> bodies = [];
         public int bodyCount;
         public long id64;
         public string name;
@@ -2133,7 +2133,7 @@ namespace SrvSurvey.canonn
         public double semiMajorAxis; // 0.0093306383208345
         public CanonnBodyBioStatsSignals signals; // {…}
         public Dictionary<string, float> solidComposition; // {…}
-        public List<Station> stations;
+        public List<Station> stations = [];
         public string subType; // "Rocky body"
         public double surfacePressure; // 0.00113836642487047
         public double surfaceTemperature; // 158.876053

--- a/SrvSurvey/net/EDSM.cs
+++ b/SrvSurvey/net/EDSM.cs
@@ -140,7 +140,7 @@ namespace SrvSurvey.net.EDSM
         public string name;
         [JsonProperty(NullValueHandling = NullValueHandling.Ignore, DefaultValueHandling = DefaultValueHandling.IgnoreAndPopulate)]
         public int bodyCount;
-        public List<EdsmBody> bodies;
+        public List<EdsmBody> bodies = [];
 
         public override string ToString()
         {
@@ -178,7 +178,7 @@ namespace SrvSurvey.net.EDSM
         public long id64;
         public string name;
         public string url;
-        public List<Station> stations;
+        public List<Station> stations = [];
 
         public class Station
         {

--- a/SrvSurvey/net/NullListContractResolver.cs
+++ b/SrvSurvey/net/NullListContractResolver.cs
@@ -1,0 +1,27 @@
+using Newtonsoft.Json;
+using Newtonsoft.Json.Serialization;
+using System.Collections;
+using System.Reflection;
+
+namespace SrvSurvey.net;
+
+/// <summary>
+/// A custom contract resolver that ignores null values for list properties during deserialization.
+/// When combined with field initializers (e.g., `List&lt;T&gt; items = []`), this ensures that
+/// lists keep their initialized empty value instead of being set to null from JSON.
+/// </summary>
+internal class NullListContractResolver : DefaultContractResolver
+{
+    protected override JsonProperty CreateProperty(MemberInfo member, MemberSerialization memberSerialization)
+    {
+        var property = base.CreateProperty(member, memberSerialization);
+
+        // For any IList property, ignore null values (keeps the initialized empty list)
+        if (property.PropertyType != null && typeof(IList).IsAssignableFrom(property.PropertyType))
+        {
+            property.NullValueHandling = NullValueHandling.Ignore;
+        }
+
+        return property;
+    }
+}

--- a/SrvSurvey/net/spansh-search.cs
+++ b/SrvSurvey/net/spansh-search.cs
@@ -221,7 +221,7 @@ namespace SrvSurvey.net
             public string search_reference;
             /// <summary> Size of this page </summary>
             public int size;
-            public List<T> results;
+            public List<T> results = [];
 
             public override string ToString()
             {
@@ -252,7 +252,7 @@ namespace SrvSurvey.net
 
                 public List<Body>? bodies;
 
-                public List<MinorFactionPresence> minor_faction_presences;
+                public List<MinorFactionPresence> minor_faction_presences = [];
 
                 public override string ToString()
                 {

--- a/SrvSurvey/net/spansh.cs
+++ b/SrvSurvey/net/spansh.cs
@@ -1096,7 +1096,7 @@ namespace SrvSurvey.net
         {
             public string allegiance;
             public int bodyCount;
-            public List<Body> bodies;
+            public List<Body> bodies = [];
             public StarPos coords;
             public DateTimeOffset date;
             public string government;
@@ -1105,8 +1105,8 @@ namespace SrvSurvey.net
             public string primaryEconomy;
             public string secondaryEconomy;
             public string security;
-            public List<Station> stations;
-            public List<MinorFactionPresence> factions;
+            public List<Station> stations = [];
+            public List<MinorFactionPresence> factions = [];
 
             public override string ToString()
             {
@@ -1153,7 +1153,7 @@ namespace SrvSurvey.net
                 // TODO? parents[]
 
                 public List<Ring>? rings;
-                public List<Station>? stations;
+                public List<Station> stations = [];
 
                 public override string ToString()
                 {
@@ -1272,7 +1272,7 @@ namespace SrvSurvey.net
         public int count;
         public int from;
         public int size;
-        public List<Result> results;
+        public List<Result> results = [];
 
         public class Result
         {
@@ -1281,7 +1281,7 @@ namespace SrvSurvey.net
             public double y;
             public double z;
             public long population;
-            public List<MinorFactionPresence> minor_faction_presences;
+            public List<MinorFactionPresence> minor_faction_presences = [];
         }
     }
 
@@ -1377,7 +1377,7 @@ namespace SrvSurvey.net
     {
         public int count;
         public int from;
-        public List<Body> results;
+        public List<Body> results = [];
         // public XXX search; TODO: describe the initial search?
         public string search_reference;
         public int size;


### PR DESCRIPTION
Spansh returns `null` for `stations` arrays in systems without stations (e.g. neutron stars). The `getAllStations()` method assumed non-null, causing `ArgumentNullException` when creating a `List<T>` from null.

Fixes #682