### PR TITLE
Fix typo Interstellar Factions -> Interstellar Factor

### DIFF
--- a/SrvSurvey/plotters/PlotHumanSite.Designer.cs
+++ b/SrvSurvey/plotters/PlotHumanSite.Designer.cs
@@ -187,7 +187,7 @@ namespace Loc {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Interstellar factions available.
+        ///   Looks up a localized string similar to Interstellar Factor available.
         /// </summary>
         internal static string HasInterstellar {
             get {

--- a/SrvSurvey/plotters/PlotHumanSite.de.resx
+++ b/SrvSurvey/plotters/PlotHumanSite.de.resx
@@ -149,7 +149,7 @@
     <!--Machine translated-->
     <value>Interstellare Fraktionen verfügbar</value>
     <comment>Shown when approaching a settlement</comment>
-    <source>Interstellar factions available</source>
+    <source>Interstellar Factor available</source>
   </data>
   <data name="HelpFoot0">
     <!--Machine translated-->

--- a/SrvSurvey/plotters/PlotHumanSite.es.resx
+++ b/SrvSurvey/plotters/PlotHumanSite.es.resx
@@ -134,7 +134,7 @@
   <data name="HasInterstellar">
     <value>Facciones interestelares disponibles</value>
     <comment>Shown when approaching a settlement</comment>
-    <source>Interstellar factions available</source>
+    <source>Interstellar Factor available</source>
   </data>
   <data name="HelpFoot0">
     <value>Para identificar manualmente:</value>

--- a/SrvSurvey/plotters/PlotHumanSite.fr.resx
+++ b/SrvSurvey/plotters/PlotHumanSite.fr.resx
@@ -142,7 +142,7 @@
   <data name="HasInterstellar">
     <value>Interstellar Factor disponible</value>
     <comment>Shown when approaching a settlement</comment>
-    <source>Interstellar factions available</source>
+    <source>Interstellar Factor available</source>
   </data>
   <data name="HelpFoot0">
     <!--Machine translated-->

--- a/SrvSurvey/plotters/PlotHumanSite.ps.resx
+++ b/SrvSurvey/plotters/PlotHumanSite.ps.resx
@@ -149,7 +149,7 @@
     <!--Machine translated-->
     <value>* INTERSTELLAR FACTIONS AVAILABLE →→→!</value>
     <comment>Shown when approaching a settlement</comment>
-    <source>Interstellar factions available</source>
+    <source>Interstellar Factor available</source>
   </data>
   <data name="HelpFoot0">
     <!--Machine translated-->

--- a/SrvSurvey/plotters/PlotHumanSite.pt-BR.resx
+++ b/SrvSurvey/plotters/PlotHumanSite.pt-BR.resx
@@ -149,7 +149,7 @@
     <!--Machine translated-->
     <value>Facções interestelares disponíveis</value>
     <comment>Shown when approaching a settlement</comment>
-    <source>Interstellar factions available</source>
+    <source>Interstellar Factor available</source>
   </data>
   <data name="HelpFoot0">
     <!--Machine translated-->

--- a/SrvSurvey/plotters/PlotHumanSite.resx
+++ b/SrvSurvey/plotters/PlotHumanSite.resx
@@ -152,7 +152,7 @@
     <comment>Shown when approaching a settlement</comment>
   </data>
   <data name="HasInterstellar">
-    <value>Interstellar factions available</value>
+    <value>Interstellar Factor available</value>
     <comment>Shown when approaching a settlement</comment>
   </data>
   

--- a/SrvSurvey/plotters/PlotHumanSite.ru.resx
+++ b/SrvSurvey/plotters/PlotHumanSite.ru.resx
@@ -134,7 +134,7 @@
   <data name="HasInterstellar">
     <value>Доступен Interstellar Factors</value>
     <comment>Shown when approaching a settlement</comment>
-    <source>Interstellar factions available</source>
+    <source>Interstellar Factor available</source>
   </data>
   <data name="HelpFoot0">
     <value>Для определения вручную:</value>

--- a/SrvSurvey/plotters/PlotHumanSite.zh-Hans.resx
+++ b/SrvSurvey/plotters/PlotHumanSite.zh-Hans.resx
@@ -138,7 +138,7 @@
   <data name="HasInterstellar">
     <value>可用星际派系</value>
     <comment>Shown when approaching a settlement</comment>
-    <source>Interstellar factions available</source>
+    <source>Interstellar Factor available</source>
   </data>
   <data name="HelpFoot0">
     <value>手动识别:</value>


### PR DESCRIPTION
There's what I assume is a repeated typo of the contact where you can turn in bounties, pay your own fines/bounties, etc. This should fix it

https://elite-dangerous.fandom.com/wiki/Interstellar_Factor