### PR TITLE
fix(threading): marshal clipboard operation to UI thread

### DIFF
--- a/SrvSurvey/Util.cs
+++ b/SrvSurvey/Util.cs
@@ -790,7 +790,13 @@ namespace SrvSurvey
                     MessageBoxButtons.YesNo,
                     MessageBoxIcon.Warning);
 
-                if (rslt == DialogResult.Yes) Clipboard.SetText(Application.ExecutablePath);
+                if (rslt == DialogResult.Yes)
+                {
+                    if (Program.control.InvokeRequired)
+                        Program.control.Invoke(() => Clipboard.SetText(Application.ExecutablePath));
+                    else
+                        Clipboard.SetText(Application.ExecutablePath);
+                }
                 return true;
             }
 


### PR DESCRIPTION
Clipboard operations require the calling thread to be in Single-Threaded Apartment mode. The UI thread has this, threadpool threads don't.

`isFirewallProblem()` is called from `ContinueWith` handlers on network tasks. `ContinueWith` (unlike `await`) doesn't capture the synchronization context, so these run on threadpool threads. When the user clicks "Yes" to copy the exe path, `Clipboard.SetText` throws `ThreadStateException`.

Check `InvokeRequired` and marshal to UI thread when needed.

Fixes #669