### PR TITLE
fix(threading): capture current boxel to avoid race in findSystemsFromNavRoute

### DIFF
--- a/SrvSurvey/game/BoxelSearch.cs
+++ b/SrvSurvey/game/BoxelSearch.cs
@@ -321,21 +321,22 @@ namespace SrvSurvey.game
 
         private bool findSystemsFromNavRoute(List<RouteEntry>? route)
         {
-            if (route == null || this.current == null) return false;
+            var currentBoxel = this.current;
+            if (route == null || currentBoxel == null) return false;
 
             var dirty = false;
             foreach (var hop in route)
             {
-                if (hop == null || this.current == null) continue;
+                if (hop == null) continue;
                 var bx = Boxel.parse(hop.SystemAddress, hop.StarSystem);
-                if (bx == null || bx.prefix != this.current.prefix) continue;
+                if (bx == null || bx.prefix != currentBoxel.prefix) continue;
                 dirty = true;
 
                 // merge data
                 var sys = findOrAddSystem(bx);
                 sys.starPos ??= hop.StarPos;
 
-                setProgress(current, bx.n2 + 1);
+                setProgress(currentBoxel, bx.n2 + 1);
             }
 
             return dirty;


### PR DESCRIPTION
The fix in bf3f1402 added null checks, but there's still a TOCTOU race - `this.current` is checked at line 324/329 but accessed again at line 331 (`this.current.prefix`). If another thread nulls it between those lines, NullRef.

Capture `this.current` into a local variable once at method entry, use that throughout.

Fixes #649