### PR TITLE
fix: prevent bodyScans double-counting from DSS scans

### DIFF
--- a/SrvSurvey/game/CommanderJourney.cs
+++ b/SrvSurvey/game/CommanderJourney.cs
@@ -278,7 +278,11 @@ namespace SrvSurvey.game
             // ignore asteroid clusters
             if (entry.PlanetClass == null && entry.StarType == null) return;
 
-            // Effectively (but not entirely) FSS scans
+            // track which bodies we've counted to avoid double-counting from DSS scans
+            currentSystem.bodiesScanned ??= new();
+            if (currentSystem.bodiesScanned.Contains(entry.BodyID)) return;
+            currentSystem.bodiesScanned.Add(entry.BodyID);
+
             currentSystem.count.bodyScans++;
 
             if (entry.StarType != null)
@@ -503,6 +507,8 @@ namespace SrvSurvey.game
             public Dictionary<string, int>? landedOn;
             [JsonProperty(NullValueHandling = NullValueHandling.Ignore, DefaultValueHandling = DefaultValueHandling.IgnoreAndPopulate)]
             public HashSet<long>? codexScanned;
+            [JsonProperty(NullValueHandling = NullValueHandling.Ignore, DefaultValueHandling = DefaultValueHandling.IgnoreAndPopulate)]
+            public HashSet<int>? bodiesScanned;
             [JsonProperty(NullValueHandling = NullValueHandling.Ignore, DefaultValueHandling = DefaultValueHandling.IgnoreAndPopulate)]
             public HashSet<string>? codexNew;
             [JsonProperty(NullValueHandling = NullValueHandling.Ignore, DefaultValueHandling = DefaultValueHandling.IgnoreAndPopulate)]


### PR DESCRIPTION
DSS creates a second Scan journal event for bodies already scanned with FSS. The `onJournalEntry(Scan)` handler increments `bodyScans` unconditionally, so DSS-ing a body counts it twice.

Track scanned BodyIDs in a HashSet, only increment on first encounter.

Fixes #204