### PR TITLE
fix: deduplicate commodities in assign dropdown

### DIFF
--- a/SrvSurvey/forms/FormBuildAssign.cs
+++ b/SrvSurvey/forms/FormBuildAssign.cs
@@ -15,7 +15,7 @@ namespace SrvSurvey.forms
             InitializeComponent();
 
             txtCmdr.Text = cmdr;
-            comboCommodity.Items.AddRange(commodities.ToArray());
+            comboCommodity.Items.AddRange(commodities.Distinct().ToArray());
         }
 
         private void btnAssign_Click(object sender, EventArgs e)


### PR DESCRIPTION
Commodity dropdown shows duplicates when the same commodity appears in multiple build types.

Add `.Distinct()` when populating the list.

Fixes #637