### PR TITLE
feat: show refuel indicator in jump overlay for Spansh routes

### DIFF
--- a/SrvSurvey/plotters/PlotJumpInfo.cs
+++ b/SrvSurvey/plotters/PlotJumpInfo.cs
@@ -180,6 +180,9 @@ namespace SrvSurvey.plotters
                     // and show any notes
                     if (nextHop.notes != null)
                         set.Add(nextHop.notes!);
+                    // show refuel indicator from Spansh route
+                    if (nextHop.refuel)
+                        set.Add("⛽ REFUEL");
                 }
             }
 


### PR DESCRIPTION
The `refuel` flag from Spansh galaxy routes was already being parsed and stored in `FollowRoute.Hop`, just not displayed in the jump overlay.

Show "⛽ REFUEL" in the route hop info when the flag is set.

Fixes #673