### PR TITLE
fix(threading): lock bodies collection in prepSettlements

### DIFF
--- a/SrvSurvey/game/SystemData.cs
+++ b/SrvSurvey/game/SystemData.cs
@@ -1638,7 +1638,8 @@ namespace SrvSurvey.game
             var sites = GuardianSitePub.Find(this.name);
             Game.log($"prepSettlements: for: '{this.name}' ({this.address}), sites.Count: {sites.Count}");
             this._settlements = new List<SystemSettlementSummary>();
-            var bodies = this.bodies.ToList();
+            List<SystemBody> bodies;
+            lock (this.bodies) { bodies = this.bodies.ToList(); }
             foreach (var site in sites)
             {
                 if (site.isRuins)


### PR DESCRIPTION
Lock bodies collection before calling ToList() in prepSettlements - prevents 'Collection was modified' exception when another thread modifies the list during enumeration. Uses the existing lock pattern from findOrCreate.

Fixes #676
Fixes #521