### PR TITLE
fix: guard FormPlayJournal against null journals and Slice underflow

### DIFF
--- a/SrvSurvey/forms/FormPlayComms.cs
+++ b/SrvSurvey/forms/FormPlayComms.cs
@@ -35,7 +35,7 @@ namespace SrvSurvey.forms
 
             lastLeftBtn = btnQuests;
 
-            btnWatch.Enabled = Game.activeGame != null;
+            btnWatch.Enabled = Game.activeGame?.journals != null;
 
             foreach (var btn in new DrawButton[] { btnClose, btnQuests, btnMsgs, btnWatch, btnDev })
                 btn.setGameColors();
@@ -540,7 +540,7 @@ namespace SrvSurvey.forms
 
         private void btnWatch_Click(object sender, EventArgs e)
         {
-            if (Game.activeGame != null)
+            if (Game.activeGame?.journals != null)
                 BaseForm.show<FormPlayJournal>();
         }
 
@@ -551,7 +551,7 @@ namespace SrvSurvey.forms
 
         private void FormPlayComms_Activated(object sender, EventArgs e)
         {
-            btnWatch.Enabled = Game.activeGame != null;
+            btnWatch.Enabled = Game.activeGame?.journals != null;
         }
 
 

--- a/SrvSurvey/forms/FormPlayJournal.cs
+++ b/SrvSurvey/forms/FormPlayJournal.cs
@@ -27,7 +27,8 @@ namespace SrvSurvey.forms
         {
             if (game.journals == null) return;
 
-            var entries = game.journals.Entries.Slice(game.journals.Entries.Count - 120, 120).ToList();
+            var count = Math.Min(120, game.journals.Entries.Count);
+            var entries = game.journals.Entries.Slice(game.journals.Entries.Count - count, count).ToList();
             foreach (var entry in entries)
             {
                 var obj = JObject.FromObject(entry);


### PR DESCRIPTION
## Summary

- Check `Game.activeGame?.journals != null` before enabling/showing the watch window, not just `activeGame != null`
- Clamp `Slice` start index in `pullPriorEntries` when fewer than 120 journal entries exist

### Root cause

`Game.activeGame` is set in the constructor before `journals` or `status` are initialized, and is never cleared on `Dispose()`. `FormPlayJournal`'s constructor unconditionally dereferences both. Separately, `pullPriorEntries` passes a negative start to `Slice` when `Entries.Count < 120`.

Fixes #851