### PR TITLE
fix: defensive null checks and resource leak from code review

### DIFF
--- a/SrvSurvey/forms/BaseForm.cs
+++ b/SrvSurvey/forms/BaseForm.cs
@@ -128,7 +128,7 @@ namespace SrvSurvey.forms
         protected void applySavedLocation()
         {
             // can we fit in our last location?
-            var savedRect = Game.settings.formLocations.GetValueOrDefault(this.GetType().Name);
+            var savedRect = Game.settings.formLocations.GetValueOrDefault(this.Name);
             if (savedRect.Size != Size.Empty && !this.IsDisposed)
             {
                 var sizable = this.FormBorderStyle.ToString().StartsWith("Sizable");

--- a/SrvSurvey/forms/FormPlayComms.cs
+++ b/SrvSurvey/forms/FormPlayComms.cs
@@ -18,7 +18,7 @@ namespace SrvSurvey.forms
         private string mode = "quests";
         private Control lastLeftBtn;
         public string? lastListName;
-        private Dictionary<string, string> mappedGameKeyBinds;
+        private Dictionary<string, string> mappedGameKeyBinds = new();
 
         public FormPlayComms()
         {
@@ -252,6 +252,7 @@ namespace SrvSurvey.forms
 
         private void showQuests()
         {
+            if (cmdrPlay == null) return;
             clearSelection();
             tlist.SuspendLayout();
 
@@ -336,6 +337,7 @@ namespace SrvSurvey.forms
 
         private void showMsgs()
         {
+            if (cmdrPlay == null) return;
             clearSelection();
 
             var allMsgs = cmdrPlay.activeQuests
@@ -569,7 +571,13 @@ namespace SrvSurvey.forms
 
             // use the first line to know which .binds file to read
             var lines = File.ReadAllLines(filepath);
-            filepath = Directory.GetFiles(Elite.keybingsFolder, $"{lines[0]}.*.binds").Last();
+            var bindsFiles = Directory.GetFiles(Elite.keybingsFolder, $"{lines[0]}.*.binds");
+            if (bindsFiles.Length == 0)
+            {
+                Game.log($"No .binds files found matching: {lines[0]}");
+                return null;
+            }
+            filepath = bindsFiles.Last();
             if (!File.Exists(filepath))
             {
                 Game.log($"File not found: {filepath}");
@@ -596,15 +604,26 @@ namespace SrvSurvey.forms
 
         private static void mapKeyBind(Dictionary<string, string> bindsMap, XElement root, string gameBind, string mapsTo)
         {
-            var binds = root.Element(gameBind)!.Elements();
+            var element = root.Element(gameBind);
+            if (element == null) return;
+            var binds = element.Elements().ToList();
+            if (binds.Count == 0) return;
 
-            var primary = matchGameKeybind(binds.First()!.Attribute("Key")!.Value);
-            if (primary != null)
-                bindsMap[primary] = mapsTo;
+            var primaryKey = binds.First().Attribute("Key")?.Value;
+            if (primaryKey != null)
+            {
+                var primary = matchGameKeybind(primaryKey);
+                if (primary != null)
+                    bindsMap[primary] = mapsTo;
+            }
 
-            var secondary = matchGameKeybind(binds.Last().Attribute("Key")!.Value);
-            if (secondary != null)
-                bindsMap[secondary] = mapsTo;
+            var secondaryKey = binds.Last().Attribute("Key")?.Value;
+            if (secondaryKey != null)
+            {
+                var secondary = matchGameKeybind(secondaryKey);
+                if (secondary != null)
+                    bindsMap[secondary] = mapsTo;
+            }
         }
 
         public static string? matchGameKeybind(string key)
@@ -936,7 +955,7 @@ namespace SrvSurvey.forms
 
         private void prepBodyText()
         {
-            var raw = pm.body ?? qm?.body!;
+            var raw = pm.body ?? qm?.body ?? "";
 
             var matchParts = new Regex("`(.+?)`");
             var matches = matchParts.Matches(raw);

--- a/SrvSurvey/forms/FormPlayJournal.cs
+++ b/SrvSurvey/forms/FormPlayJournal.cs
@@ -125,9 +125,9 @@ namespace SrvSurvey.forms
             var obj = node?.Tag as JObject;
             if (obj == null) return;
 
-            var entry = JournalFile.hydrate(obj)!;
+            var entry = JournalFile.hydrate(obj);
             if (entry != null)
-                game.cmdrPlay!.processJournalEntry(entry).justDoIt();
+                game.cmdrPlay?.processJournalEntry(entry).justDoIt();
         }
     }
 }

--- a/SrvSurvey/game/Game.cs
+++ b/SrvSurvey/game/Game.cs
@@ -3432,6 +3432,7 @@ namespace SrvSurvey.game
             var list = this.systemBody.bookmarks[name]
                 .Select(_ => new TrackingDelta(this.systemBody.radius, _, location))
                 .ToList();
+            if (list.Count == 0) return;
             list.Sort((a, b) => a.distance.CompareTo(b.distance));
 
             var victim = list[nearest ? 0 : list.Count - 1].Target;

--- a/SrvSurvey/game/JournalWatcher.cs
+++ b/SrvSurvey/game/JournalWatcher.cs
@@ -47,6 +47,7 @@ namespace SrvSurvey
                 if (this.watcher != null)
                 {
                     this.watcher.Changed -= JournalWatcher_Changed;
+                    this.watcher.Dispose();
                     this.watcher = null;
                 }
             }

--- a/SrvSurvey/quests/PlayChapter.cs
+++ b/SrvSurvey/quests/PlayChapter.cs
@@ -35,7 +35,7 @@ public class PlayChapter
 
     #endregion
 
-    private string src => pq.quest.chapters[id];
+    private string? src => pq.quest.chapters.GetValueOrDefault(id);
 
     /// <summary> Returns true if this chapter is currently active </summary>
     [JsonIgnore] public bool active => !endTime.HasValue && startTime.HasValue;

--- a/SrvSurvey/quests/PlayState.cs
+++ b/SrvSurvey/quests/PlayState.cs
@@ -58,7 +58,7 @@ internal class PlayState : Data
 
                 // TODO: use a server for this ...
                 var questPath = Path.Combine(folder, $"{pq.id}.json");
-                if (!File.Exists(filepath)) throw new Exception($"Missing! {questPath}");
+                if (!File.Exists(questPath)) throw new Exception($"Missing! {questPath}");
 
                 var questJson = File.ReadAllText(questPath);
                 pq.quest = JsonConvert.DeserializeObject<DefQuest>(questJson)!;
@@ -213,7 +213,7 @@ internal class PlayState : Data
 
         // start first chapter?
         var firstChapter = pq.chapters.FirstOrDefault(c => c.id == newQuest.firstChapter);
-        if (firstChapter!.endTime == null)
+        if (firstChapter != null && firstChapter.endTime == null)
             await pq.startChapter(newQuest.firstChapter);
 
         this.Save();


### PR DESCRIPTION
## Summary

Fixes found during a systematic code review across forms, quest system, journal watcher, and game state management. All are null safety, bounds checking, or resource management issues.

### Quest system
- **PlayState.cs:61** — `File.Exists(filepath)` checked wrong variable; should be `questPath`
- **PlayState.cs:216** — `FirstOrDefault()` result dereferenced without null check
- **PlayChapter.cs:38** — dictionary lookup via indexer replaced with `GetValueOrDefault` to prevent `KeyNotFoundException`

### FormPlayComms
- **Line 21** — `mappedGameKeyBinds` uninitialized; any keypress crashes if keybind parsing returns null
- **Line 572** — `Directory.GetFiles().Last()` crashes on empty result set
- **Lines 599-615** — `mapKeyBind` null-forgiving operators on XML elements/attributes
- **Lines 258, 341** — `cmdrPlay` accessed without null check in `showQuests()`/`showMsgs()`
- **Line 939** — `pm.body ?? qm?.body!` crashes if both null; now falls back to `""`

### FormPlayJournal
- **Line 127-129** — null-forgiving operators on `hydrate()` result and `cmdrPlay`

### JournalWatcher
- **Line 50** — `FileSystemWatcher` never disposed, leaking file handles

### BaseForm
- **Line 131** — `applySavedLocation()` used `this.GetType().Name` but `saveLocation()` uses `this.Name`, causing mismatched keys

### Game
- **Line 3437** — `removeBookmark` crashes on empty bookmark list (`list[list.Count - 1]` with count 0)