### PR TITLE
fix: null guards for game.status/systemBody in plotter drawing methods

### DIFF
--- a/SrvSurvey/plotters/PlotBase.cs
+++ b/SrvSurvey/plotters/PlotBase.cs
@@ -538,12 +538,12 @@ namespace SrvSurvey.plotters
 
         protected void drawCommander0()
         {
-            if (g == null) return;
+            if (g == null || game.status == null) return;
 
             // draw current location pointer (always at center of plot + unscaled)
             g.ResetTransform();
             g.TranslateTransform(mid.Width, mid.Height);
-            g.RotateTransform(360 - game.status!.Heading);
+            g.RotateTransform(360 - game.status.Heading);
 
             var locSz = 5f;
             g.DrawEllipse(GameColors.penLime2, -locSz, -locSz, locSz * 2, locSz * 2);
@@ -568,9 +568,9 @@ namespace SrvSurvey.plotters
 
         protected void drawCompassLines(int heading = -1)
         {
-            if (g == null) return;
+            if (g == null || game.status == null) return;
 
-            if (heading == -1) heading = game.status!.Heading;
+            if (heading == -1) heading = game.status.Heading;
 
             g.ResetTransform();
             this.clipToMiddle();
@@ -592,7 +592,8 @@ namespace SrvSurvey.plotters
             g.ResetTransform();
             g.TranslateTransform(mid.Width, mid.Height);
             g.ScaleTransform(scale, scale);
-            g.RotateTransform(360 - game.status!.Heading);
+            if (game.status == null) return;
+            g.RotateTransform(360 - game.status.Heading);
 
             // draw touchdown marker
             if (game.touchdownLocation != null && game.systemBody != null)
@@ -646,8 +647,9 @@ namespace SrvSurvey.plotters
 
         protected void drawBearingTo(float x, float y, string txt, LatLong2 location)
         {
-            var dd = new TrackingDelta(game.systemBody!.radius, location);
-            Angle deg = dd.angle - game.status!.Heading;
+            if (game.systemBody == null || game.status == null) return;
+            var dd = new TrackingDelta(game.systemBody.radius, location);
+            Angle deg = dd.angle - game.status.Heading;
 
             drawBearingTo(x, y, txt, (double)dd.distance, (double)deg);
         }

--- a/SrvSurvey/plotters/PlotBase2.cs
+++ b/SrvSurvey/plotters/PlotBase2.cs
@@ -600,6 +600,7 @@ namespace SrvSurvey.plotters
         /// <summary> center in middle, scaled and rotated by player's heading </summary>
         protected void resetMiddleRotated(Graphics g)
         {
+            if (game.status == null) return;
             g.ResetTransform();
             g.TranslateTransform(mid.Width, mid.Height);
             g.ScaleTransform(scale, scale);
@@ -616,6 +617,8 @@ namespace SrvSurvey.plotters
         /// <summary> Centered on current origin </summary>
         protected virtual void drawCompassLines(Graphics g)
         {
+            if (game.status == null) return;
+
             // draw black background checks
             g.FillRectangle(GameColors.adjustGroundChecks(scale), -width, -height, width * 2, height * 2);
 
@@ -652,7 +655,7 @@ namespace SrvSurvey.plotters
             }
 
             // draw touchdown marker
-            if (game.cmdr.lastTouchdownLocation != null)
+            if (game.cmdr?.lastTouchdownLocation != null && game.status != null)
             {
                 RectangleF rect;
                 var shipSize = 24f / this.scale;
@@ -738,11 +741,12 @@ namespace SrvSurvey.plotters
             this.distToSiteOrigin = Util.getDistance(siteLocation, Status.here, this.radius);
             this.offsetWithoutHeading = (PointF)Util.getOffset(this.radius, this.siteLocation); // explicitly EXCLUDING site.heading
             this.cmdrOffset = (PointF)Util.getOffset(radius, siteLocation, siteHeading); // explicitly INCLUDING site.heading
-            this.cmdrHeading = game.status.Heading - siteHeading;
+            this.cmdrHeading = status.Heading - siteHeading;
         }
 
         protected void resetMiddleSiteOrigin(Graphics g)
         {
+            if (game.status == null) return;
             g.ResetTransform();
             g.TranslateTransform(mid.Width, mid.Height); // shift to center of window
             g.ScaleTransform(scale, scale); // apply display scale factor (zoom)


### PR DESCRIPTION
## Summary

- Add `game.status == null` guards in `PlotBase` drawing methods: `drawCommander0`, `drawCompassLines`, `drawTouchdownAndSrvLocation0`, `drawBearingTo`
- Add `game.status == null` guards in `PlotBase2` methods: `resetMiddleRotated`, `drawCompassLines`, `drawShipAndSrvLocation`, `resetMiddleSiteOrigin`
- Add `game.systemBody == null` guard in `drawBearingTo`
- Fix `onStatusChange` to use the passed `status` parameter instead of re-reading `game.status`

Defensive hardening from code review. These methods use `game.status!` (null-forgiving) but `game.status` can be null after `Game.Dispose()` or during incomplete initialization. No known crash reports trace to these specific methods, but the pattern is fragile given that plotter rendering continues during game state transitions.