### PR TITLE
fix: add missing FileSystemWatcher.Dispose() calls

### DIFF
--- a/SrvSurvey/forms/FormPlayDev.cs
+++ b/SrvSurvey/forms/FormPlayDev.cs
@@ -286,6 +286,7 @@ namespace SrvSurvey.forms
             folderWatcher.Changed -= FolderWatcher_Changed;
             folderWatcher.Renamed -= FolderWatcher_Changed;
             folderWatcher.Deleted -= FolderWatcher_Changed;
+            folderWatcher.Dispose();
             folderWatcher = null;
 
             checkWatchFolder.Checked = false;

--- a/SrvSurvey/game/Cargo.cs
+++ b/SrvSurvey/game/Cargo.cs
@@ -100,6 +100,7 @@ namespace SrvSurvey
                 if (this.fileWatcher != null)
                 {
                     this.fileWatcher.Changed -= fileWatcher_Changed;
+                    this.fileWatcher.Dispose();
                     this.fileWatcher = null;
                 }
             }

--- a/SrvSurvey/game/NavRoute.cs
+++ b/SrvSurvey/game/NavRoute.cs
@@ -79,6 +79,7 @@ namespace SrvSurvey
                 if (this.fileWatcher != null)
                 {
                     this.fileWatcher.Changed -= fileWatcher_Changed;
+                    this.fileWatcher.Dispose();
                     this.fileWatcher = null;
                 }
             }

--- a/SrvSurvey/game/Status.cs
+++ b/SrvSurvey/game/Status.cs
@@ -80,6 +80,7 @@ namespace SrvSurvey
                 if (this.fileWatcher != null)
                 {
                     this.fileWatcher.Changed -= fileWatcher_Changed;
+                    this.fileWatcher.Dispose();
                     this.fileWatcher = null;
                 }
             }

--- a/SrvSurvey/plotters/PlotGuardians.cs
+++ b/SrvSurvey/plotters/PlotGuardians.cs
@@ -1031,7 +1031,7 @@ namespace SrvSurvey.plotters
             this.invalidate();
         }
 
-        private FileSystemWatcher watcher;
+        private FileSystemWatcher? watcher;
 
         private void devFileWatcher()
         {
@@ -1046,6 +1046,17 @@ namespace SrvSurvey.plotters
             this.watcher.Changed += Watcher_Changed;
             this.watcher.NotifyFilter = NotifyFilters.LastWrite | NotifyFilters.Size;
             this.watcher.EnableRaisingEvents = true;
+        }
+
+        protected override void onClose()
+        {
+            if (this.watcher != null)
+            {
+                this.watcher.Changed -= Watcher_Changed;
+                this.watcher.Dispose();
+                this.watcher = null;
+            }
+            base.onClose();
         }
 
         private void Watcher_Changed(object sender, FileSystemEventArgs e)

--- a/SrvSurvey/plotters/PlotHumanSite.cs
+++ b/SrvSurvey/plotters/PlotHumanSite.cs
@@ -96,11 +96,13 @@ namespace SrvSurvey.plotters
             if (this.mapImageWatcher != null)
             {
                 this.mapImageWatcher.Changed -= MapImageWatcher_Changed;
+                this.mapImageWatcher.Dispose();
                 this.mapImageWatcher = null;
             }
             if (this.templateWatcher != null)
             {
                 this.templateWatcher.Changed -= TemplateWatcher_Changed;
+                this.templateWatcher.Dispose();
                 this.templateWatcher = null;
             }
 


### PR DESCRIPTION
## Summary

Follow-up to #853 where `JournalWatcher` got its `.Dispose()` call added. The same pattern (remove handler + null, but no `Dispose()`) existed in 6 other files:

- **Cargo.cs**, **NavRoute.cs**, **Status.cs**: `fileWatcher` nulled without dispose in cleanup
- **PlotHumanSite.cs**: `mapImageWatcher` and `templateWatcher` nulled without dispose
- **FormPlayDev.cs**: `folderWatcher` nulled without dispose in `stopWatching()`
- **PlotGuardians.cs**: `watcher` never cleaned up — added `onClose()` override with full dispose + handler removal

`FileSystemWatcher` holds native OS file handles that only get released on GC finalization if `Dispose()` isn't called. Not a crash risk, but a resource leak.

Relates to feedback on #853