### PR TITLE
feat: planet visit order optimizer

### DIFF
--- a/.github/workflows/dotnet-desktop.yml
+++ b/.github/workflows/dotnet-desktop.yml
@@ -75,7 +75,12 @@ jobs:
     - name: Install .NET Core
       uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: 7.0.x
+        dotnet-version: |
+          7.0.x
+          8.0.x
+
+    - name: Test orbital route calculations
+      run: dotnet test tests/SrvSurvey.OrbitalTests/SrvSurvey.OrbitalTests.csproj --configuration Release
 
     # Add  MSBuild to the PATH: https://github.com/microsoft/setup-msbuild
     - name: Setup MSBuild.exe

--- a/SrvSurvey/Settings.cs
+++ b/SrvSurvey/Settings.cs
@@ -110,6 +110,7 @@ namespace SrvSurvey
         public int hideFssLowValueAmount = 10_000;
         public bool skipHighDistanceDSS = false;
         public int skipHighDistanceDSSValue = 100_000;
+        public bool showDssVisitRoute = false;
         public bool showNonBodySignals = false;
         public bool autoTrackCompBioScans = true;
         public bool skipAnalyzedCompBioScans = true;

--- a/SrvSurvey/forms/FormSettings.Designer.cs
+++ b/SrvSurvey/forms/FormSettings.Designer.cs
@@ -184,6 +184,7 @@ namespace SrvSurvey
             checkBox11 = new CheckBox2();
             checkBox10 = new CheckBox2();
             checkBox9 = new CheckBox2();
+            checkDssVisitRoute = new CheckBox2();
             checkBox8 = new CheckBox2();
             checkBox4 = new CheckBox2();
             tabExternalData = new TabPage();
@@ -2092,6 +2093,7 @@ namespace SrvSurvey
             tabPage6.Controls.Add(checkBox11);
             tabPage6.Controls.Add(checkBox10);
             tabPage6.Controls.Add(checkBox9);
+            tabPage6.Controls.Add(checkDssVisitRoute);
             tabPage6.Controls.Add(checkBox8);
             tabPage6.Controls.Add(checkBox4);
             tabPage6.Location = new Point(4, 24);
@@ -2515,6 +2517,19 @@ namespace SrvSurvey
             checkBox9.Tag = "skipGasGiantDSS";
             checkBox9.Text = "Skip DSS of gas giants";
             checkBox9.UseVisualStyleBackColor = true;
+            //
+            // checkDssVisitRoute
+            //
+            checkDssVisitRoute.AutoSize = true;
+            checkDssVisitRoute.CheckColor = SystemColors.ControlText;
+            checkDssVisitRoute.LineColor = SystemColors.ActiveBorder;
+            checkDssVisitRoute.Location = new Point(508, 127);
+            checkDssVisitRoute.Name = "checkDssVisitRoute";
+            checkDssVisitRoute.Size = new Size(179, 19);
+            checkDssVisitRoute.TabIndex = 36;
+            checkDssVisitRoute.Tag = "showDssVisitRoute";
+            checkDssVisitRoute.Text = "Show optimized DSS route";
+            checkDssVisitRoute.UseVisualStyleBackColor = true;
             // 
             // checkBox8
             // 
@@ -3885,6 +3900,7 @@ namespace SrvSurvey
         private PictureBox pictureBox5;
         private CheckBox2 checkBox8;
         private CheckBox2 checkBox9;
+        private CheckBox2 checkDssVisitRoute;
         private CheckBox2 checkBox10;
         private CheckBox2 checkBox11;
         private NumericUpDown numMinScanValue;

--- a/SrvSurvey/game/OrbitalMechanics.cs
+++ b/SrvSurvey/game/OrbitalMechanics.cs
@@ -1,0 +1,232 @@
+namespace SrvSurvey.game
+{
+    /// <summary>
+    /// Calculates orbital positions using Keplerian orbital mechanics.
+    /// Based on standard two-body problem formulas (see Wikipedia: Orbital elements).
+    /// </summary>
+    internal class OrbitalCalculator
+    {
+        /// <summary>
+        /// Double-precision 3D vector (System.Numerics.Vector3 uses float which loses
+        /// precision at large orbital distances -- 100 AU in km needs more than 7 digits).
+        /// </summary>
+        public struct Vec3d
+        {
+            public double X, Y, Z;
+
+            public Vec3d(double x, double y, double z) { X = x; Y = y; Z = z; }
+
+            public static Vec3d operator +(Vec3d a, Vec3d b)
+                => new Vec3d(a.X + b.X, a.Y + b.Y, a.Z + b.Z);
+
+            public double DistanceTo(Vec3d other)
+            {
+                double dx = X - other.X, dy = Y - other.Y, dz = Z - other.Z;
+                return Math.Sqrt(dx * dx + dy * dy + dz * dz);
+            }
+        }
+
+        /// <summary>
+        /// Represents a body's orbital parameters (Keplerian elements).
+        /// </summary>
+        public class OrbitalBody
+        {
+            public int BodyId { get; set; }
+            public string Name { get; set; } = "";
+
+            // Keplerian orbital elements
+            public double SemiMajorAxis { get; set; }      // meters
+            public double Eccentricity { get; set; }        // 0-1
+            public double Inclination { get; set; }         // degrees
+            public double ArgumentOfPeriapsis { get; set; }  // degrees (ω)
+            public double LongitudeAscendingNode { get; set; } // degrees (Ω)
+            public double MeanAnomalyAtEpoch { get; set; }  // degrees
+            public DateTime Epoch { get; set; }             // timestamp for mean anomaly
+            public double OrbitalPeriod { get; set; }       // seconds
+            public double Radius { get; set; }              // meters (body radius)
+
+            // Immediate parent only (first entry in journal Parents array)
+            public int ParentId { get; set; } = -1;
+
+            // Cached absolute position (km)
+            public Vec3d Position { get; set; }
+        }
+
+        private Dictionary<int, OrbitalBody> bodies = new Dictionary<int, OrbitalBody>();
+
+        /// <summary>
+        /// Add a body to the orbital system.
+        /// </summary>
+        public void AddBody(OrbitalBody body)
+        {
+            bodies[body.BodyId] = body;
+        }
+
+        /// <summary>
+        /// Calculate absolute positions of all bodies at the given time.
+        /// Uses recursive descent so parents are always computed before children.
+        /// </summary>
+        public void UpdatePositions(DateTime time)
+        {
+            var computed = new HashSet<int>();
+            foreach (var body in bodies.Values)
+                ComputeAbsolutePosition(body, time, computed);
+        }
+
+        private void ComputeAbsolutePosition(OrbitalBody body, DateTime time, HashSet<int> computed)
+        {
+            if (computed.Contains(body.BodyId))
+                return;
+
+            // Compute this body's position relative to its immediate parent
+            var relativePos = CalculateOrbitalPosition(body, time);
+            body.Position = relativePos;
+
+            // Add the immediate parent's absolute position (which already includes all ancestors)
+            if (body.ParentId >= 0 && bodies.TryGetValue(body.ParentId, out var parent))
+            {
+                ComputeAbsolutePosition(parent, time, computed);
+                body.Position = body.Position + parent.Position;
+            }
+
+            computed.Add(body.BodyId);
+        }
+
+        /// <summary>
+        /// Calculate orbital position using Keplerian two-body mechanics.
+        /// Returns position in kilometers relative to immediate parent.
+        /// </summary>
+        private Vec3d CalculateOrbitalPosition(OrbitalBody body, DateTime time)
+        {
+            // Root bodies (stars with no orbit) sit at the origin
+            if (body.SemiMajorAxis <= 0 || body.OrbitalPeriod <= 0)
+                return new Vec3d(0, 0, 0);
+
+            // Convert to radians and km
+            double a = body.SemiMajorAxis / 1000.0; // meters to km
+            double e = body.Eccentricity;
+            double i = body.Inclination * Math.PI / 180.0;
+            double omega = body.ArgumentOfPeriapsis * Math.PI / 180.0;
+            double Omega = body.LongitudeAscendingNode * Math.PI / 180.0;
+            double M0 = body.MeanAnomalyAtEpoch * Math.PI / 180.0;
+
+            // Mean Anomaly at current time
+            double deltaTime = (time - body.Epoch).TotalSeconds;
+            double meanMotion = 2.0 * Math.PI / body.OrbitalPeriod;
+            double M = M0 + meanMotion * deltaTime;
+
+            // Normalize to [0, 2π)
+            M = M % (2.0 * Math.PI);
+            if (M < 0) M += 2.0 * Math.PI;
+
+            // Solve Kepler's equation for Eccentric Anomaly
+            double E = SolveKeplersEquation(M, e);
+
+            // True Anomaly via half-angle formula
+            double nu = 2.0 * Math.Atan2(
+                Math.Sqrt(1.0 + e) * Math.Sin(E / 2.0),
+                Math.Sqrt(1.0 - e) * Math.Cos(E / 2.0)
+            );
+
+            // Radial distance from focus
+            double r = a * (1.0 - e * Math.Cos(E));
+
+            // Position in orbital plane (perifocal frame)
+            double xP = r * Math.Cos(nu);
+            double yP = r * Math.Sin(nu);
+
+            // Perifocal-to-inertial rotation: R_z(-Ω) · R_x(-i) · R_z(-ω)
+            double cO = Math.Cos(Omega), sO = Math.Sin(Omega);
+            double ci = Math.Cos(i), si = Math.Sin(i);
+            double cw = Math.Cos(omega), sw = Math.Sin(omega);
+
+            double x = (cO * cw - sO * sw * ci) * xP + (-cO * sw - sO * cw * ci) * yP;
+            double y = (sO * cw + cO * sw * ci) * xP + (-sO * sw + cO * cw * ci) * yP;
+            double z = (sw * si) * xP + (cw * si) * yP;
+
+            return new Vec3d(x, y, z);
+        }
+
+        /// <summary>
+        /// Solve Kepler's equation M = E - e·sin(E) via Newton-Raphson iteration.
+        /// </summary>
+        private static double SolveKeplersEquation(double M, double e, double tol = 1e-10, int maxIter = 30)
+        {
+            // Initial guess (good for small e)
+            double E = M + e * Math.Sin(M) * (1.0 + e * Math.Cos(M));
+
+            for (int n = 0; n < maxIter; n++)
+            {
+                double dE = (E - e * Math.Sin(E) - M) / (1.0 - e * Math.Cos(E));
+                E -= dE;
+                if (Math.Abs(dE) < tol) break;
+            }
+
+            return E;
+        }
+
+        /// <summary>
+        /// Euclidean distance between two bodies in light-seconds.
+        /// </summary>
+        public double GetDistanceLightSeconds(int bodyId1, int bodyId2)
+        {
+            if (!bodies.TryGetValue(bodyId1, out var b1) || !bodies.TryGetValue(bodyId2, out var b2))
+                return double.MaxValue;
+
+            double distanceKm = b1.Position.DistanceTo(b2.Position);
+            return distanceKm / 299792.458;
+        }
+
+        public bool HasBody(int bodyId) => bodies.ContainsKey(bodyId);
+
+        public OrbitalBody? GetBody(int bodyId)
+            => bodies.TryGetValue(bodyId, out var body) ? body : null;
+
+        public IEnumerable<OrbitalBody> GetAllBodies() => bodies.Values;
+    }
+
+    /// <summary>
+    /// Route optimizer using greedy nearest-neighbor heuristic for TSP.
+    /// </summary>
+    internal static class RouteOptimizer
+    {
+        /// <summary>
+        /// Find an efficient route visiting all target bodies, starting from startBodyId.
+        /// Returns ordered list of body IDs including the start.
+        /// </summary>
+        public static List<int> OptimizeRoute(int startBodyId, List<int> targetBodyIds, OrbitalCalculator calculator)
+        {
+            var route = new List<int> { startBodyId };
+            var remaining = new HashSet<int>(targetBodyIds.Where(id => id != startBodyId));
+
+            if (remaining.Count == 0)
+                return route;
+
+            int current = startBodyId;
+
+            while (remaining.Count > 0)
+            {
+                int nearest = -1;
+                double minDist = double.MaxValue;
+
+                foreach (var id in remaining)
+                {
+                    double d = calculator.GetDistanceLightSeconds(current, id);
+                    if (d < minDist)
+                    {
+                        minDist = d;
+                        nearest = id;
+                    }
+                }
+
+                if (nearest == -1) break;
+
+                route.Add(nearest);
+                remaining.Remove(nearest);
+                current = nearest;
+            }
+
+            return route;
+        }
+    }
+}

--- a/SrvSurvey/game/OrbitalMechanics.cs
+++ b/SrvSurvey/game/OrbitalMechanics.cs
@@ -24,6 +24,8 @@ namespace SrvSurvey.game
                 double dx = X - other.X, dy = Y - other.Y, dz = Z - other.Z;
                 return Math.Sqrt(dx * dx + dy * dy + dz * dz);
             }
+
+            public bool IsFinite => double.IsFinite(X) && double.IsFinite(Y) && double.IsFinite(Z);
         }
 
         /// <summary>
@@ -48,8 +50,12 @@ namespace SrvSurvey.game
             // Immediate parent only (first entry in journal Parents array)
             public int ParentId { get; set; } = -1;
 
+            public bool IsRoot { get; set; }
+            public bool HasOrbitalElements { get; set; }
+
             // Cached absolute position (km)
             public Vec3d Position { get; set; }
+            public bool PositionValid { get; set; }
         }
 
         private Dictionary<int, OrbitalBody> bodies = new Dictionary<int, OrbitalBody>();
@@ -69,38 +75,63 @@ namespace SrvSurvey.game
         public void UpdatePositions(DateTime time)
         {
             var computed = new HashSet<int>();
+            var visiting = new HashSet<int>();
             foreach (var body in bodies.Values)
-                ComputeAbsolutePosition(body, time, computed);
+                ComputeAbsolutePosition(body, time, computed, visiting);
         }
 
-        private void ComputeAbsolutePosition(OrbitalBody body, DateTime time, HashSet<int> computed)
+        private bool ComputeAbsolutePosition(OrbitalBody body, DateTime time, HashSet<int> computed, HashSet<int> visiting)
         {
             if (computed.Contains(body.BodyId))
-                return;
+                return body.PositionValid;
 
-            // Compute this body's position relative to its immediate parent
-            var relativePos = CalculateOrbitalPosition(body, time);
-            body.Position = relativePos;
-
-            // Add the immediate parent's absolute position (which already includes all ancestors)
-            if (body.ParentId >= 0 && bodies.TryGetValue(body.ParentId, out var parent))
+            if (!visiting.Add(body.BodyId))
             {
-                ComputeAbsolutePosition(parent, time, computed);
-                body.Position = body.Position + parent.Position;
+                body.PositionValid = false;
+                computed.Add(body.BodyId);
+                return false;
             }
 
+            if (body.IsRoot)
+            {
+                body.Position = new Vec3d(0, 0, 0);
+                body.PositionValid = true;
+            }
+            else if (!body.HasOrbitalElements || !TryCalculateOrbitalPosition(body, time, out var relativePos))
+            {
+                body.PositionValid = false;
+            }
+            else if (body.ParentId < 0 || !bodies.TryGetValue(body.ParentId, out var parent)
+                || !ComputeAbsolutePosition(parent, time, computed, visiting))
+            {
+                body.PositionValid = false;
+            }
+            else
+            {
+                body.Position = relativePos + parent.Position;
+                body.PositionValid = body.Position.IsFinite;
+            }
+
+            visiting.Remove(body.BodyId);
             computed.Add(body.BodyId);
+            return body.PositionValid;
         }
 
         /// <summary>
         /// Calculate orbital position using Keplerian two-body mechanics.
         /// Returns position in kilometers relative to immediate parent.
         /// </summary>
-        private Vec3d CalculateOrbitalPosition(OrbitalBody body, DateTime time)
+        private bool TryCalculateOrbitalPosition(OrbitalBody body, DateTime time, out Vec3d position)
         {
-            // Root bodies (stars with no orbit) sit at the origin
-            if (body.SemiMajorAxis <= 0 || body.OrbitalPeriod <= 0)
-                return new Vec3d(0, 0, 0);
+            position = default;
+            if (!double.IsFinite(body.SemiMajorAxis) || body.SemiMajorAxis <= 0
+                || !double.IsFinite(body.OrbitalPeriod) || body.OrbitalPeriod <= 0
+                || !double.IsFinite(body.Eccentricity) || body.Eccentricity < 0 || body.Eccentricity >= 1
+                || !double.IsFinite(body.Inclination)
+                || !double.IsFinite(body.ArgumentOfPeriapsis)
+                || !double.IsFinite(body.LongitudeAscendingNode)
+                || !double.IsFinite(body.MeanAnomalyAtEpoch))
+                return false;
 
             // Convert to radians and km — negate angles to match game coordinate system
             double a = body.SemiMajorAxis / 1000.0; // meters to km
@@ -120,7 +151,8 @@ namespace SrvSurvey.game
             if (M < 0) M += 2.0 * Math.PI;
 
             // Solve Kepler's equation for Eccentric Anomaly
-            double E = SolveKeplersEquation(M, e);
+            if (!TrySolveKeplersEquation(M, e, out double E))
+                return false;
 
             // True Anomaly via half-angle formula
             double nu = 2.0 * Math.Atan2(
@@ -144,25 +176,44 @@ namespace SrvSurvey.game
             double y = (sO * cw + cO * sw * ci) * xP + (-sO * sw + cO * cw * ci) * yP;
             double z = (sw * si) * xP + (cw * si) * yP;
 
-            return new Vec3d(x, y, z);
+            position = new Vec3d(x, y, z);
+            return position.IsFinite;
         }
 
         /// <summary>
         /// Solve Kepler's equation M = E - e·sin(E) via Newton-Raphson iteration.
         /// </summary>
-        private static double SolveKeplersEquation(double M, double e, double tol = 1e-10, int maxIter = 30)
+        private static bool TrySolveKeplersEquation(double M, double e, out double eccentricAnomaly, double tol = 1e-10, int maxIter = 30)
         {
             // Initial guess (good for small e)
             double E = M + e * Math.Sin(M) * (1.0 + e * Math.Cos(M));
 
             for (int n = 0; n < maxIter; n++)
             {
-                double dE = (E - e * Math.Sin(E) - M) / (1.0 - e * Math.Cos(E));
+                double denominator = 1.0 - e * Math.Cos(E);
+                if (!double.IsFinite(denominator) || Math.Abs(denominator) < double.Epsilon)
+                {
+                    eccentricAnomaly = default;
+                    return false;
+                }
+
+                double dE = (E - e * Math.Sin(E) - M) / denominator;
+                if (!double.IsFinite(dE))
+                {
+                    eccentricAnomaly = default;
+                    return false;
+                }
+
                 E -= dE;
-                if (Math.Abs(dE) < tol) break;
+                if (Math.Abs(dE) < tol)
+                {
+                    eccentricAnomaly = E;
+                    return true;
+                }
             }
 
-            return E;
+            eccentricAnomaly = default;
+            return false;
         }
 
         /// <summary>
@@ -170,8 +221,9 @@ namespace SrvSurvey.game
         /// </summary>
         public double GetDistanceLightSeconds(int bodyId1, int bodyId2)
         {
-            if (!bodies.TryGetValue(bodyId1, out var b1) || !bodies.TryGetValue(bodyId2, out var b2))
-                return double.MaxValue;
+            if (!bodies.TryGetValue(bodyId1, out var b1) || !b1.PositionValid
+                || !bodies.TryGetValue(bodyId2, out var b2) || !b2.PositionValid)
+                return double.PositiveInfinity;
 
             double distanceKm = b1.Position.DistanceTo(b2.Position);
             return distanceKm / 299792.458;
@@ -179,30 +231,62 @@ namespace SrvSurvey.game
 
         public bool HasBody(int bodyId) => bodies.ContainsKey(bodyId);
 
+        public bool HasValidPosition(int bodyId)
+            => bodies.TryGetValue(bodyId, out var body) && body.PositionValid;
+
         public OrbitalBody? GetBody(int bodyId)
             => bodies.TryGetValue(bodyId, out var body) ? body : null;
 
         public IEnumerable<OrbitalBody> GetAllBodies() => bodies.Values;
     }
 
+    internal static class OrbitalHierarchy
+    {
+        public static bool IsSystemRoot(int parentId, bool isMainStar, bool isBarycentre)
+            => parentId < 0 && (isMainStar || isBarycentre);
+
+        /// <summary>
+        /// Build immediate-parent relationships from journal parent chains. Each chain
+        /// is ordered from the body's immediate parent through the system root.
+        /// </summary>
+        public static Dictionary<int, int> InferParentIds(
+            IEnumerable<(int BodyId, IReadOnlyList<int> ParentChain)> bodies)
+        {
+            var parentIds = new Dictionary<int, int>();
+            foreach (var (bodyId, parentChain) in bodies)
+            {
+                if (parentChain.Count == 0)
+                    continue;
+
+                parentIds.TryAdd(bodyId, parentChain[0]);
+                for (int index = 0; index + 1 < parentChain.Count; index++)
+                    parentIds.TryAdd(parentChain[index], parentChain[index + 1]);
+            }
+            return parentIds;
+        }
+    }
+
     /// <summary>
-    /// Route optimizer: exact solution for small systems, heuristic for large ones.
+    /// Route optimizer: exact dynamic-programming solution for small systems, heuristic for large ones.
     /// </summary>
     internal static class RouteOptimizer
     {
-        private const int ExactThreshold = 10;
+        private const int ExactThreshold = 15;
 
         /// <summary>
         /// Find an efficient route visiting all target bodies, starting from startBodyId.
-        /// Uses exact permutation search for up to 10 targets, nearest-neighbor + 2-opt above that.
+        /// Uses Held-Karp dynamic programming for up to 15 targets, nearest-neighbor + 2-opt above that.
         /// Returns ordered list of body IDs including the start.
         /// </summary>
         public static List<int> OptimizeRoute(int startBodyId, List<int> targetBodyIds, OrbitalCalculator calculator)
         {
-            var targets = targetBodyIds.Where(id => id != startBodyId).ToList();
+            var targets = targetBodyIds.Where(id => id != startBodyId).Distinct().OrderBy(id => id).ToList();
 
             if (targets.Count == 0)
                 return new List<int> { startBodyId };
+
+            if (!calculator.HasValidPosition(startBodyId) || targets.Any(id => !calculator.HasValidPosition(id)))
+                return new List<int>();
 
             if (targets.Count <= ExactThreshold)
                 return ExactShortestRoute(startBodyId, targets, calculator);
@@ -212,45 +296,82 @@ namespace SrvSurvey.game
 
         private static List<int> ExactShortestRoute(int startId, List<int> targets, OrbitalCalculator calc)
         {
-            var bestPerm = new List<int>(targets);
-            double bestDist = double.MaxValue;
+            int count = targets.Count;
+            int stateCount = 1 << count;
+            var costs = new double[stateCount, count];
+            var previous = new int[stateCount, count];
 
-            Permute(targets, 0, startId, calc, ref bestPerm, ref bestDist);
-
-            var route = new List<int>(bestPerm.Count + 1) { startId };
-            route.AddRange(bestPerm);
-            return route;
-        }
-
-        private static void Permute(List<int> arr, int start, int startId, OrbitalCalculator calc,
-            ref List<int> bestPerm, ref double bestDist)
-        {
-            if (start == arr.Count)
+            for (int mask = 0; mask < stateCount; mask++)
             {
-                double dist = calc.GetDistanceLightSeconds(startId, arr[0]);
-                for (int i = 1; i < arr.Count; i++)
-                    dist += calc.GetDistanceLightSeconds(arr[i - 1], arr[i]);
-
-                if (dist < bestDist)
+                for (int target = 0; target < count; target++)
                 {
-                    bestDist = dist;
-                    bestPerm = new List<int>(arr);
+                    costs[mask, target] = double.PositiveInfinity;
+                    previous[mask, target] = -1;
                 }
-                return;
             }
 
-            for (int i = start; i < arr.Count; i++)
+            for (int target = 0; target < count; target++)
+                costs[1 << target, target] = calc.GetDistanceLightSeconds(startId, targets[target]);
+
+            for (int mask = 1; mask < stateCount; mask++)
             {
-                (arr[start], arr[i]) = (arr[i], arr[start]);
-                Permute(arr, start + 1, startId, calc, ref bestPerm, ref bestDist);
-                (arr[start], arr[i]) = (arr[i], arr[start]);
+                for (int last = 0; last < count; last++)
+                {
+                    if ((mask & (1 << last)) == 0 || !double.IsFinite(costs[mask, last]))
+                        continue;
+
+                    for (int next = 0; next < count; next++)
+                    {
+                        int nextBit = 1 << next;
+                        if ((mask & nextBit) != 0)
+                            continue;
+
+                        int nextMask = mask | nextBit;
+                        double candidate = costs[mask, last] + calc.GetDistanceLightSeconds(targets[last], targets[next]);
+                        if (candidate < costs[nextMask, next])
+                        {
+                            costs[nextMask, next] = candidate;
+                            previous[nextMask, next] = last;
+                        }
+                    }
+                }
             }
+
+            int fullMask = stateCount - 1;
+            int bestLast = -1;
+            double bestCost = double.PositiveInfinity;
+            for (int last = 0; last < count; last++)
+            {
+                if (costs[fullMask, last] < bestCost)
+                {
+                    bestCost = costs[fullMask, last];
+                    bestLast = last;
+                }
+            }
+
+            if (bestLast < 0 || !double.IsFinite(bestCost))
+                return new List<int>();
+
+            var orderedTargets = new List<int>(count);
+            int currentMask = fullMask;
+            while (bestLast >= 0)
+            {
+                orderedTargets.Add(targets[bestLast]);
+                int prior = previous[currentMask, bestLast];
+                currentMask &= ~(1 << bestLast);
+                bestLast = prior;
+            }
+            orderedTargets.Reverse();
+
+            var route = new List<int>(count + 1) { startId };
+            route.AddRange(orderedTargets);
+            return route;
         }
 
         private static List<int> HeuristicRoute(int startId, List<int> targets, OrbitalCalculator calc)
         {
             var route = new List<int> { startId };
-            var remaining = new HashSet<int>(targets);
+            var remaining = new SortedSet<int>(targets);
             int current = startId;
 
             while (remaining.Count > 0)

--- a/SrvSurvey/game/SystemData.cs
+++ b/SrvSurvey/game/SystemData.cs
@@ -1699,6 +1699,22 @@ namespace SrvSurvey.game
             return names;
         }
 
+        public List<int> getDssRemainingBodyIds()
+        {
+            var ids = new List<int>();
+            var ordered = this.bodies.OrderBy(_ => _.id);
+            foreach (var _ in ordered)
+            {
+                if (_.dssComplete) continue;
+                if (_.type != SystemBodyType.Giant && _.type != SystemBodyType.SolidBody && _.type != SystemBodyType.LandableBody) continue;
+                if (Game.settings.skipGasGiantDSS && _.type == SystemBodyType.Giant) continue;
+                if (Game.settings.skipLowValueDSS && _.rewardEstimate < Game.settings.skipLowValueAmount) continue;
+                if (Game.settings.skipHighDistanceDSS && _.distanceFromArrivalLS > Game.settings.skipHighDistanceDSSValue) continue;
+                ids.Add(_.id);
+            }
+            return ids;
+        }
+
         public List<string> getBioRemainingNames()
         {
             var names = this.bodies
@@ -2033,9 +2049,12 @@ namespace SrvSurvey.game
         #region orbital route optimization
 
         /// <summary>
-        /// Calculate optimal visit order for bodies worth mapping/visiting using orbital mechanics.
+        /// Calculate optimal visit order for the given target bodies using orbital mechanics.
         /// </summary>
-        public void CalculateOptimalRoute()
+        [JsonIgnore]
+        public OrbitalCalculator? lastCalculator;
+
+        public void CalculateOptimalRoute(List<int> targetBodyIds)
         {
             try
             {
@@ -2043,13 +2062,9 @@ namespace SrvSurvey.game
                 foreach (var body in bodies)
                     body.visitOrder = 0;
 
-                // Find bodies worth visiting (high value, unmapped, bio signals, etc.)
-                var worthVisiting = bodies
-                    .Where(b => b.shouldVisit)
-                    .Select(b => b.id)
-                    .ToList();
+                lastCalculator = null;
 
-                if (worthVisiting.Count == 0)
+                if (targetBodyIds.Count == 0)
                     return;
 
                 // Build orbital calculator with all bodies (including root bodies at origin)
@@ -2098,7 +2113,7 @@ namespace SrvSurvey.game
                     startBodyId = bodies.FirstOrDefault(b => b.isMainStar)?.id ?? 0;
 
                 // Optimize route
-                var route = RouteOptimizer.OptimizeRoute(startBodyId, worthVisiting, calculator);
+                var route = RouteOptimizer.OptimizeRoute(startBodyId, targetBodyIds, calculator);
 
                 // Set visit orders (skip first as it's the starting position)
                 for (int i = 1; i < route.Count; i++)
@@ -2108,7 +2123,8 @@ namespace SrvSurvey.game
                         body.visitOrder = i;
                 }
 
-                Game.log($"Calculated optimal route for {worthVisiting.Count} bodies in {this.name}");
+                lastCalculator = calculator;
+                Game.log($"Calculated optimal route for {targetBodyIds.Count} bodies in {this.name}");
             }
             catch (Exception ex)
             {

--- a/SrvSurvey/game/SystemData.cs
+++ b/SrvSurvey/game/SystemData.cs
@@ -679,6 +679,7 @@ namespace SrvSurvey.game
             body.absoluteMagnitude = entry.AbsoluteMagnitude;
             body.radius = entry.Radius;
             body.parents = entry.Parents;
+            this.invalidateOptimalRoute();
             body.wasDiscovered = entry.WasDiscovered;
             if (!body.wasMapped && entry.WasMapped) body.wasMapped = true;
             if (entry.WasFootfalled.HasValue && entry.WasFootfalled.Value)
@@ -830,6 +831,7 @@ namespace SrvSurvey.game
             body.orbitalPeriod = entry.OrbitalPeriod;
             body.ascendingNode = entry.AscendingNode;
             body.orbitalEpoch = entry.timestamp;
+            this.invalidateOptimalRoute();
 
             return true;
         }
@@ -1661,58 +1663,49 @@ namespace SrvSurvey.game
         public bool suppressBioOverlays;
 
         public List<string> getDssRemainingNames()
+            => this.getDssRemainingTargets().Select(target => target.name).ToList();
+
+        public List<int> getDssRemainingBodyIds()
+            => this.getDssRemainingTargets().Select(target => target.bodyId).Distinct().ToList();
+
+        private List<(int bodyId, string name)> getDssRemainingTargets()
         {
-            var names = new List<string>();
-            var ordered = this.bodies.OrderBy(_ => _.id);
-            foreach (var _ in ordered)
+            var targets = new List<(int bodyId, string name)>();
+            var ordered = this.bodies.OrderBy(body => body.id).ToList();
+            foreach (var body in ordered)
             {
                 // skip things already scanned
-                if (_.dssComplete) continue;
+                if (body.dssComplete) continue;
 
                 // skip anything except Scannable planets
-                if (_.type != SystemBodyType.Giant && _.type != SystemBodyType.SolidBody && _.type != SystemBodyType.LandableBody) continue;
+                if (body.type != SystemBodyType.Giant && body.type != SystemBodyType.SolidBody && body.type != SystemBodyType.LandableBody) continue;
 
-                // inject rings
-                if (!Game.settings.skipRingsDSS && _.hasRings)
+                // Rings use their parent body as the route destination and remain eligible
+                // even when the parent body itself is excluded by a body-specific filter.
+                if (!Game.settings.skipRingsDSS && body.hasRings)
                 {
-                    for (int n = 0; n < _.rings.Count; n++)
+                    for (int n = 0; n < body.rings.Count; n++)
                     {
-                        var ringNotScanned = ordered.FirstOrDefault(b => b.name == _.rings[n].name)?.dssComplete != true;
+                        var ringNotScanned = ordered.FirstOrDefault(candidate => candidate.name == body.rings[n].name)?.dssComplete != true;
                         if (ringNotScanned)
-                            names.Add(_.shortName + $"r{(char)(n + 'A')}");
+                            targets.Add((body.id, body.shortName + $"r{(char)(n + 'A')}"));
                     }
                 }
 
                 // optionally skip gas giants
-                if (Game.settings.skipGasGiantDSS && _.type == SystemBodyType.Giant) continue;
+                if (Game.settings.skipGasGiantDSS && body.type == SystemBodyType.Giant) continue;
 
                 // optionally skip low value bodies
-                if (Game.settings.skipLowValueDSS && _.rewardEstimate < Game.settings.skipLowValueAmount) continue;
+                if (Game.settings.skipLowValueDSS && body.rewardEstimate < Game.settings.skipLowValueAmount) continue;
 
                 // optionally skip anything too far away
-                if (Game.settings.skipHighDistanceDSS && _.distanceFromArrivalLS > Game.settings.skipHighDistanceDSSValue)
+                if (Game.settings.skipHighDistanceDSS && body.distanceFromArrivalLS > Game.settings.skipHighDistanceDSSValue)
                     continue;
 
-                names.Add(_.shortName);
+                targets.Add((body.id, body.shortName));
             }
 
-            return names;
-        }
-
-        public List<int> getDssRemainingBodyIds()
-        {
-            var ids = new List<int>();
-            var ordered = this.bodies.OrderBy(_ => _.id);
-            foreach (var _ in ordered)
-            {
-                if (_.dssComplete) continue;
-                if (_.type != SystemBodyType.Giant && _.type != SystemBodyType.SolidBody && _.type != SystemBodyType.LandableBody) continue;
-                if (Game.settings.skipGasGiantDSS && _.type == SystemBodyType.Giant) continue;
-                if (Game.settings.skipLowValueDSS && _.rewardEstimate < Game.settings.skipLowValueAmount) continue;
-                if (Game.settings.skipHighDistanceDSS && _.distanceFromArrivalLS > Game.settings.skipHighDistanceDSSValue) continue;
-                ids.Add(_.id);
-            }
-            return ids;
+            return targets;
         }
 
         public List<string> getBioRemainingNames()
@@ -2054,6 +2047,13 @@ namespace SrvSurvey.game
         [JsonIgnore]
         public OrbitalCalculator? lastCalculator;
 
+        private static readonly TimeSpan optimalRouteCacheDuration = TimeSpan.FromSeconds(30);
+        private readonly List<int> optimalRouteCache = new();
+        private string? optimalRouteCacheKey;
+        private DateTime optimalRouteCachedAt;
+        private OrbitalCalculator? optimalRouteCacheCalculator;
+        private int orbitalRouteVersion;
+
         public void CalculateOptimalRoute(List<int> targetBodyIds)
         {
             try
@@ -2062,74 +2062,95 @@ namespace SrvSurvey.game
                 foreach (var body in bodies)
                     body.visitOrder = 0;
 
-                lastCalculator = null;
-
-                if (targetBodyIds.Count == 0)
+                var targets = targetBodyIds.Distinct().OrderBy(id => id).ToList();
+                if (targets.Count == 0)
                     return;
 
-                // Build orbital calculator with all bodies (including root bodies at origin)
+                // Start from player's current body if known, otherwise main star.
+                int startBodyId = Game.activeGame?.cmdr?.currentBodyId ?? -1;
+                if (startBodyId < 0 || bodies.All(body => body.id != startBodyId))
+                    startBodyId = bodies.FirstOrDefault(body => body.isMainStar)?.id ?? 0;
+
+                string cacheKey = $"{orbitalRouteVersion}:{startBodyId}:{string.Join(',', targets)}";
+                if (cacheKey == optimalRouteCacheKey && DateTime.UtcNow - optimalRouteCachedAt < optimalRouteCacheDuration)
+                {
+                    applyVisitOrder(optimalRouteCache);
+                    lastCalculator = optimalRouteCacheCalculator;
+                    return;
+                }
+
+                // Parent chains on ordinary Scan events let us infer parents for
+                // ScanBaryCentre bodies, whose journal event has no Parents field.
+                var parentIds = inferOrbitalParentIds();
                 var calculator = new OrbitalCalculator();
                 foreach (var body in bodies)
                 {
-                    // Immediate parent is the first entry in the Parents list
-                    int parentId = body.parents?.FirstOrDefault()?.id ?? -1;
-
-                    if (body.semiMajorAxis > 0 && body.orbitalPeriod > 0 && body.orbitalEpoch.HasValue)
+                    int parentId = parentIds.GetValueOrDefault(body.id, -1);
+                    bool hasOrbitalElements = body.semiMajorAxis > 0 && body.orbitalPeriod > 0 && body.orbitalEpoch.HasValue;
+                    calculator.AddBody(new OrbitalCalculator.OrbitalBody
                     {
-                        calculator.AddBody(new OrbitalCalculator.OrbitalBody
-                        {
-                            BodyId = body.id,
-                            Name = body.name,
-                            SemiMajorAxis = body.semiMajorAxis,
-                            Eccentricity = body.eccentricity,
-                            Inclination = body.orbitalInclination,
-                            ArgumentOfPeriapsis = body.periapsis,
-                            LongitudeAscendingNode = body.ascendingNode,
-                            MeanAnomalyAtEpoch = body.meanAnomaly,
-                            Epoch = body.orbitalEpoch.Value.UtcDateTime,
-                            OrbitalPeriod = body.orbitalPeriod,
-                            Radius = (double)body.radius,
-                            ParentId = parentId,
-                        });
-                    }
-                    else
-                    {
-                        // Root bodies (main star, barycentres with no orbit) placed at origin
-                        calculator.AddBody(new OrbitalCalculator.OrbitalBody
-                        {
-                            BodyId = body.id,
-                            Name = body.name,
-                            ParentId = parentId,
-                        });
-                    }
+                        BodyId = body.id,
+                        Name = body.name,
+                        SemiMajorAxis = body.semiMajorAxis,
+                        Eccentricity = body.eccentricity,
+                        Inclination = body.orbitalInclination,
+                        ArgumentOfPeriapsis = body.periapsis,
+                        LongitudeAscendingNode = body.ascendingNode,
+                        MeanAnomalyAtEpoch = body.meanAnomaly,
+                        Epoch = body.orbitalEpoch?.UtcDateTime ?? default,
+                        OrbitalPeriod = body.orbitalPeriod,
+                        Radius = (double)body.radius,
+                        ParentId = parentId,
+                        IsRoot = OrbitalHierarchy.IsSystemRoot(parentId, body.isMainStar, body.type == SystemBodyType.Barycentre),
+                        HasOrbitalElements = hasOrbitalElements,
+                    });
                 }
 
-                // Calculate current positions
                 calculator.UpdatePositions(DateTime.UtcNow);
+                var route = RouteOptimizer.OptimizeRoute(startBodyId, targets, calculator);
 
-                // Start from player's current body if known, otherwise main star
-                int startBodyId = Game.activeGame?.cmdr?.currentBodyId ?? -1;
-                if (startBodyId < 0 || !calculator.HasBody(startBodyId))
-                    startBodyId = bodies.FirstOrDefault(b => b.isMainStar)?.id ?? 0;
+                optimalRouteCacheKey = cacheKey;
+                optimalRouteCachedAt = DateTime.UtcNow;
+                optimalRouteCache.Clear();
+                optimalRouteCache.AddRange(route);
+                optimalRouteCacheCalculator = calculator;
+                lastCalculator = calculator;
 
-                // Optimize route
-                var route = RouteOptimizer.OptimizeRoute(startBodyId, targetBodyIds, calculator);
-
-                // Set visit orders (skip first as it's the starting position)
-                for (int i = 1; i < route.Count; i++)
+                if (route.Count == 0)
                 {
-                    var body = bodies.FirstOrDefault(b => b.id == route[i]);
-                    if (body != null)
-                        body.visitOrder = i;
+                    Game.log($"Cannot calculate an optimized route for {this.name}: orbital data or parent relationships are incomplete.");
+                    return;
                 }
 
-                lastCalculator = calculator;
-                Game.log($"Calculated optimal route for {targetBodyIds.Count} bodies in {this.name}");
+                applyVisitOrder(route);
+                Game.log($"Calculated optimal route for {targets.Count} bodies in {this.name}");
             }
             catch (Exception ex)
             {
-                Game.log($"Error calculating optimal route: {ex.Message}");
+                Game.log($"Error calculating optimal route: {ex.Message}\r\n\t{ex.StackTrace}");
             }
+        }
+
+        private void applyVisitOrder(IReadOnlyList<int> route)
+        {
+            for (int i = 1; i < route.Count; i++)
+            {
+                var body = bodies.FirstOrDefault(candidate => candidate.id == route[i]);
+                if (body != null)
+                    body.visitOrder = i;
+            }
+        }
+
+        private Dictionary<int, int> inferOrbitalParentIds()
+            => OrbitalHierarchy.InferParentIds(bodies.OrderBy(body => body.id).Select(body =>
+                (body.id, (IReadOnlyList<int>)(body.parents?.Select(parent => parent.id).ToList() ?? new List<int>()))));
+
+        private void invalidateOptimalRoute()
+        {
+            orbitalRouteVersion++;
+            optimalRouteCacheKey = null;
+            optimalRouteCache.Clear();
+            optimalRouteCacheCalculator = null;
         }
 
         #endregion
@@ -2301,7 +2322,7 @@ namespace SrvSurvey.game
         public DateTimeOffset? orbitalEpoch;
 
         /// <summary> Visit order for route optimization (0 = not in route, 1+ = order to visit) </summary>
-        [JsonProperty(NullValueHandling = NullValueHandling.Ignore, DefaultValueHandling = DefaultValueHandling.IgnoreAndPopulate)]
+        [JsonIgnore]
         public int visitOrder;
 
         [JsonProperty(NullValueHandling = NullValueHandling.Ignore, DefaultValueHandling = DefaultValueHandling.IgnoreAndPopulate)]
@@ -2437,38 +2458,6 @@ namespace SrvSurvey.game
 
         [JsonIgnore]
         public bool isMainStar => type == SystemBodyType.Star && (this.id == 0 || this.name.EndsWith("A"));
-
-        /// <summary>
-        /// Determine if this body is worth visiting for mapping/exploration
-        /// </summary>
-        [JsonIgnore]
-        public bool shouldVisit
-        {
-            get
-            {
-                // Skip if already mapped
-                if (this.wasMapped || this.dssComplete)
-                    return false;
-
-                // Skip non-valuable types
-                if (!this.hasValue)
-                    return false;
-
-                // Include bodies with biological signals
-                if (this.bioSignalCount > 0)
-                    return true;
-
-                // Include high-value bodies (terraformable, water worlds, ELW, etc.)
-                if (this.reward > 500000) // Configurable threshold
-                    return true;
-
-                // Include landable bodies with materials
-                if (this.type == SystemBodyType.LandableBody && this.materials?.Count > 0)
-                    return true;
-
-                return false;
-            }
-        }
 
         public bool hasParent(int targetBodyId)
         {

--- a/SrvSurvey/game/SystemData.cs
+++ b/SrvSurvey/game/SystemData.cs
@@ -669,6 +669,13 @@ namespace SrvSurvey.game
             body.mass = entry.MassEM > 0 ? entry.MassEM : entry.StellarMass; // mass
             body.distanceFromArrivalLS = entry.DistanceFromArrivalLS;
             body.semiMajorAxis = entry.SemiMajorAxis;
+            body.eccentricity = entry.Eccentricity;
+            body.orbitalInclination = entry.OrbitalInclination;
+            body.periapsis = entry.Periapsis;
+            body.meanAnomaly = entry.MeanAnomaly;
+            body.orbitalPeriod = entry.OrbitalPeriod;
+            body.ascendingNode = entry.AscendingNode;
+            body.orbitalEpoch = entry.timestamp;
             body.absoluteMagnitude = entry.AbsoluteMagnitude;
             body.radius = entry.Radius;
             body.parents = entry.Parents;
@@ -816,6 +823,13 @@ namespace SrvSurvey.game
             body.scanned = true;
             body.type = SystemBodyType.Barycentre;
             body.semiMajorAxis = entry.SemiMajorAxis;
+            body.eccentricity = entry.Eccentricity;
+            body.orbitalInclination = entry.OrbitalInclination;
+            body.periapsis = entry.Periapsis;
+            body.meanAnomaly = entry.MeanAnomaly;
+            body.orbitalPeriod = entry.OrbitalPeriod;
+            body.ascendingNode = entry.AscendingNode;
+            body.orbitalEpoch = entry.timestamp;
 
             return true;
         }
@@ -2015,6 +2029,94 @@ namespace SrvSurvey.game
 
         [JsonIgnore]
         public string folderImages => Path.Combine(Game.settings.screenshotTargetFolder!, Util.safeFilename(this.name));
+
+        #region orbital route optimization
+
+        /// <summary>
+        /// Calculate optimal visit order for bodies worth mapping/visiting using orbital mechanics.
+        /// </summary>
+        public void CalculateOptimalRoute()
+        {
+            try
+            {
+                // Reset all visit orders
+                foreach (var body in bodies)
+                    body.visitOrder = 0;
+
+                // Find bodies worth visiting (high value, unmapped, bio signals, etc.)
+                var worthVisiting = bodies
+                    .Where(b => b.shouldVisit)
+                    .Select(b => b.id)
+                    .ToList();
+
+                if (worthVisiting.Count == 0)
+                    return;
+
+                // Build orbital calculator with all bodies (including root bodies at origin)
+                var calculator = new OrbitalCalculator();
+                foreach (var body in bodies)
+                {
+                    // Immediate parent is the first entry in the Parents list
+                    int parentId = body.parents?.FirstOrDefault()?.id ?? -1;
+
+                    if (body.semiMajorAxis > 0 && body.orbitalPeriod > 0 && body.orbitalEpoch.HasValue)
+                    {
+                        calculator.AddBody(new OrbitalCalculator.OrbitalBody
+                        {
+                            BodyId = body.id,
+                            Name = body.name,
+                            SemiMajorAxis = body.semiMajorAxis,
+                            Eccentricity = body.eccentricity,
+                            Inclination = body.orbitalInclination,
+                            ArgumentOfPeriapsis = body.periapsis,
+                            LongitudeAscendingNode = body.ascendingNode,
+                            MeanAnomalyAtEpoch = body.meanAnomaly,
+                            Epoch = body.orbitalEpoch.Value.UtcDateTime,
+                            OrbitalPeriod = body.orbitalPeriod,
+                            Radius = (double)body.radius,
+                            ParentId = parentId,
+                        });
+                    }
+                    else
+                    {
+                        // Root bodies (main star, barycentres with no orbit) placed at origin
+                        calculator.AddBody(new OrbitalCalculator.OrbitalBody
+                        {
+                            BodyId = body.id,
+                            Name = body.name,
+                            ParentId = parentId,
+                        });
+                    }
+                }
+
+                // Calculate current positions
+                calculator.UpdatePositions(DateTime.UtcNow);
+
+                // Start from player's current body if known, otherwise main star
+                int startBodyId = Game.activeGame?.cmdr?.currentBodyId ?? -1;
+                if (startBodyId < 0 || !calculator.HasBody(startBodyId))
+                    startBodyId = bodies.FirstOrDefault(b => b.isMainStar)?.id ?? 0;
+
+                // Optimize route
+                var route = RouteOptimizer.OptimizeRoute(startBodyId, worthVisiting, calculator);
+
+                // Set visit orders (skip first as it's the starting position)
+                for (int i = 1; i < route.Count; i++)
+                {
+                    var body = bodies.FirstOrDefault(b => b.id == route[i]);
+                    if (body != null)
+                        body.visitOrder = i;
+                }
+
+                Game.log($"Calculated optimal route for {worthVisiting.Count} bodies in {this.name}");
+            }
+            catch (Exception ex)
+            {
+                Game.log($"Error calculating optimal route: {ex.Message}");
+            }
+        }
+
+        #endregion
     }
 
     internal class SummaryGenus
@@ -2162,6 +2264,31 @@ namespace SrvSurvey.game
         public double semiMajorAxis;
 
         [JsonProperty(NullValueHandling = NullValueHandling.Ignore, DefaultValueHandling = DefaultValueHandling.IgnoreAndPopulate)]
+        public double eccentricity;
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore, DefaultValueHandling = DefaultValueHandling.IgnoreAndPopulate)]
+        public double orbitalInclination;
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore, DefaultValueHandling = DefaultValueHandling.IgnoreAndPopulate)]
+        public double periapsis;
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore, DefaultValueHandling = DefaultValueHandling.IgnoreAndPopulate)]
+        public double meanAnomaly;
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore, DefaultValueHandling = DefaultValueHandling.IgnoreAndPopulate)]
+        public double orbitalPeriod;
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore, DefaultValueHandling = DefaultValueHandling.IgnoreAndPopulate)]
+        public double ascendingNode;
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore, DefaultValueHandling = DefaultValueHandling.IgnoreAndPopulate)]
+        public DateTimeOffset? orbitalEpoch;
+
+        /// <summary> Visit order for route optimization (0 = not in route, 1+ = order to visit) </summary>
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore, DefaultValueHandling = DefaultValueHandling.IgnoreAndPopulate)]
+        public int visitOrder;
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore, DefaultValueHandling = DefaultValueHandling.IgnoreAndPopulate)]
         public double absoluteMagnitude;
 
         [JsonProperty(NullValueHandling = NullValueHandling.Ignore, DefaultValueHandling = DefaultValueHandling.IgnoreAndPopulate)]
@@ -2294,6 +2421,38 @@ namespace SrvSurvey.game
 
         [JsonIgnore]
         public bool isMainStar => type == SystemBodyType.Star && (this.id == 0 || this.name.EndsWith("A"));
+
+        /// <summary>
+        /// Determine if this body is worth visiting for mapping/exploration
+        /// </summary>
+        [JsonIgnore]
+        public bool shouldVisit
+        {
+            get
+            {
+                // Skip if already mapped
+                if (this.wasMapped || this.dssComplete)
+                    return false;
+
+                // Skip non-valuable types
+                if (!this.hasValue)
+                    return false;
+
+                // Include bodies with biological signals
+                if (this.bioSignalCount > 0)
+                    return true;
+
+                // Include high-value bodies (terraformable, water worlds, ELW, etc.)
+                if (this.reward > 500000) // Configurable threshold
+                    return true;
+
+                // Include landable bodies with materials
+                if (this.type == SystemBodyType.LandableBody && this.materials?.Count > 0)
+                    return true;
+
+                return false;
+            }
+        }
 
         public bool hasParent(int targetBodyId)
         {

--- a/SrvSurvey/plotters/PlotSysStatus.Designer.cs
+++ b/SrvSurvey/plotters/PlotSysStatus.Designer.cs
@@ -140,5 +140,14 @@ namespace Loc {
                 return ResourceManager.GetString("NonBodySignals", resourceCulture);
             }
         }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Visit route:.
+        /// </summary>
+        internal static string VisitRoute {
+            get {
+                return ResourceManager.GetString("VisitRoute", resourceCulture);
+            }
+        }
     }
 }

--- a/SrvSurvey/plotters/PlotSysStatus.cs
+++ b/SrvSurvey/plotters/PlotSysStatus.cs
@@ -106,7 +106,178 @@ namespace SrvSurvey.plotters
                 tt.newLine(true);
             }
 
+#if DEBUG
+            this.drawRouteDebug(g, tt);
+#else
+            this.drawVisitRoute(g, tt, destinationBody);
+#endif
+
             return tt.pad(N.six, N.eight);
+        }
+
+        private void drawVisitRoute(Graphics g, TextCursor tt, string? destination)
+        {
+            var routeBodies = getVisitRouteBodies();
+            if (routeBodies.Count > 0)
+            {
+                tt.draw(N.six, Res.VisitRoute, GameColors.fontSmall2);
+                tt.dtx += N.four;
+                this.drawRouteBodies(g, tt, destination, routeBodies);
+                tt.newLine(true);
+            }
+        }
+
+#if DEBUG
+        private void drawRouteDebug(Graphics g, TextCursor tt)
+        {
+            if (game?.systemData == null) return;
+            var sd = game.systemData;
+            var df = GameColors.fontSmall2;
+            var dim = GameColors.Orange;
+
+            // Body type breakdown
+            var total = sd.bodies.Count;
+            var stars = sd.bodies.Count(b => b.type == SystemBodyType.Star);
+            var giants = sd.bodies.Count(b => b.type == SystemBodyType.Giant);
+            var solid = sd.bodies.Count(b => b.type == SystemBodyType.SolidBody);
+            var landable = sd.bodies.Count(b => b.type == SystemBodyType.LandableBody);
+            var bary = sd.bodies.Count(b => b.type == SystemBodyType.Barycentre);
+            var other = total - stars - giants - solid - landable - bary;
+
+            tt.draw(N.six, $"dbg: {total} bodies (S{stars} G{giants} R{solid} L{landable} B{bary}" + (other > 0 ? $" ?{other})" : ")"), dim, df);
+            tt.newLine(true);
+
+            // DSS filter breakdown
+            var scannable = sd.bodies.Where(b => b.type == SystemBodyType.Giant || b.type == SystemBodyType.SolidBody || b.type == SystemBodyType.LandableBody).ToList();
+            var notDss = scannable.Where(b => !b.dssComplete).ToList();
+            var afterSkips = sd.getDssRemainingBodyIds();
+
+            tt.draw(N.six, $"dbg: scannable={scannable.Count} !dss={notDss.Count} after-filters={afterSkips.Count}", dim, df);
+            tt.newLine(true);
+
+            // Show which bodies are not-dss with their types and arrival distance
+            if (notDss.Count > 0)
+            {
+                var bodyList = string.Join(" ", notDss.Select(b =>
+                {
+                    var tag = b.type == SystemBodyType.Giant ? "G" : b.type == SystemBodyType.LandableBody ? "L" : "S";
+                    var bio = b.bioSignalCount > 0 ? $"+{b.bioSignalCount}bio" : "";
+                    var dist = $"{b.distanceFromArrivalLS:F0}ls";
+                    var hasOrb = b.orbitalEpoch.HasValue ? "" : " !orb";
+                    return $"{b.shortName}({tag}{bio} {dist}{hasOrb})";
+                }));
+                tt.draw(N.six, $"dbg !dss: {bodyList}", dim, df);
+                tt.newLine(true);
+            }
+
+            // Orbital data availability
+            var withOrbit = sd.bodies.Count(b => b.semiMajorAxis > 0 && b.orbitalPeriod > 0 && b.orbitalEpoch.HasValue);
+            tt.draw(N.six, $"dbg: orbit data={withOrbit}/{total}", dim, df);
+            tt.newLine(true);
+
+            // Route calculation with hop distances
+            if (afterSkips.Count > 0)
+            {
+                sd.CalculateOptimalRoute(afterSkips);
+                var routed = sd.bodies
+                    .Where(b => b.visitOrder > 0)
+                    .OrderBy(b => b.visitOrder)
+                    .ToList();
+
+                if (routed.Count > 0)
+                {
+                    var calc = sd.lastCalculator;
+                    // Show route with real 3D hop distances
+                    var parts = new List<string>();
+                    parts.Add(routed[0].shortName);
+                    for (int i = 1; i < routed.Count; i++)
+                    {
+                        var hopLs = calc?.GetDistanceLightSeconds(routed[i - 1].id, routed[i].id) ?? 0;
+                        parts.Add($"-({hopLs:F0} ls)-> {routed[i].shortName}");
+                    }
+                    tt.draw(N.six, "Route: ", dim, df);
+                    tt.draw(string.Join(" ", parts), GameColors.Cyan, this.font);
+                    tt.newLine(true);
+
+                    // Compare: total orbital route distance vs naive arrival-distance sort
+                    if (calc != null)
+                    {
+                        var starId = sd.bodies.FirstOrDefault(b => b.isMainStar)?.id ?? 0;
+
+                        // Orbital route total distance
+                        double orbTotal = calc.GetDistanceLightSeconds(starId, routed[0].id);
+                        for (int i = 1; i < routed.Count; i++)
+                            orbTotal += calc.GetDistanceLightSeconds(routed[i - 1].id, routed[i].id);
+
+                        // Naive route: sort by arrival distance from star
+                        var naive = routed.OrderBy(b => b.distanceFromArrivalLS).ToList();
+                        double naiveTotal = calc.GetDistanceLightSeconds(starId, naive[0].id);
+                        for (int i = 1; i < naive.Count; i++)
+                            naiveTotal += calc.GetDistanceLightSeconds(naive[i - 1].id, naive[i].id);
+                        var naiveRoute = string.Join(" > ", naive.Select(b => b.shortName));
+
+                        tt.draw(N.six, $"dbg 3D total: {orbTotal:F0}ls vs naive({naiveRoute}): {naiveTotal:F0}ls", dim, df);
+                        tt.newLine(true);
+
+                        // Show 3D distances from star
+                        var distInfo = string.Join(" ", routed.Select(b =>
+                        {
+                            var d = calc.GetDistanceLightSeconds(starId, b.id);
+                            return $"{b.shortName}={d:F0}ls";
+                        }));
+                        tt.draw(N.six, $"dbg 3d dist from star: {distInfo}", dim, df);
+                        tt.newLine(true);
+                    }
+                }
+                else
+                {
+                    tt.draw(N.six, "dbg: route returned 0 bodies", dim, df);
+                    tt.newLine(true);
+                }
+            }
+        }
+#endif
+
+        private List<(string name, int order)> getVisitRouteBodies()
+        {
+            if (game?.systemData == null)
+                return new();
+
+            var remaining = game.systemData.getDssRemainingBodyIds();
+            if (remaining.Count == 0)
+                return new();
+
+            game.systemData.CalculateOptimalRoute(remaining);
+
+            return game.systemData.bodies
+                .Where(b => b.visitOrder > 0)
+                .OrderBy(b => b.visitOrder)
+                .Select(b => (name: b.shortName, order: b.visitOrder))
+                .ToList();
+        }
+
+        private void drawRouteBodies(Graphics g, TextCursor tt, string? destination, List<(string name, int order)> bodies)
+        {
+            for (int idx = 0; idx < bodies.Count; idx++)
+            {
+                var (bodyName, order) = bodies[idx];
+                if (string.IsNullOrWhiteSpace(bodyName)) continue;
+
+                if (idx > 0) tt.draw(" > ", GameColors.Orange);
+
+                var isLocal = string.IsNullOrEmpty(destination) || bodyName[0] == destination[0];
+
+                var useFont = this.font;
+                if (destination == bodyName)
+                {
+                    useFont = this.boldFont;
+                    if (!Program.isLinux) tt.dty += 1;
+                }
+                var useColor = isLocal ? GameColors.Cyan : GameColors.Orange;
+
+                tt.draw(bodyName, useColor, useFont);
+                if (destination == bodyName && !Program.isLinux) tt.dty -= 1;
+            }
         }
 
         /// <summary>

--- a/SrvSurvey/plotters/PlotSysStatus.cs
+++ b/SrvSurvey/plotters/PlotSysStatus.cs
@@ -106,11 +106,14 @@ namespace SrvSurvey.plotters
                 tt.newLine(true);
             }
 
+            if (Game.settings.showDssVisitRoute)
+            {
 #if DEBUG
-            this.drawRouteDebug(g, tt);
+                this.drawRouteDebug(g, tt);
 #else
-            this.drawVisitRoute(g, tt, destinationBody);
+                this.drawVisitRoute(g, tt, destinationBody);
 #endif
+            }
 
             return tt.pad(N.six, N.eight);
         }

--- a/SrvSurvey/plotters/PlotSysStatus.resx
+++ b/SrvSurvey/plotters/PlotSysStatus.resx
@@ -91,4 +91,8 @@
     <value>► {0} non-body signals</value>
     <comment>{0} int, count of non body signals</comment>
   </data>
+  <data name="VisitRoute" xml:space="preserve">
+    <value>Visit route:</value>
+    <comment>Header for optimal visit order section</comment>
+  </data>
 </root>

--- a/tests/SrvSurvey.OrbitalTests/OrbitalMechanicsTests.cs
+++ b/tests/SrvSurvey.OrbitalTests/OrbitalMechanicsTests.cs
@@ -1,0 +1,149 @@
+using SrvSurvey.game;
+using Xunit;
+
+namespace SrvSurvey.OrbitalTests;
+
+public class OrbitalMechanicsTests
+{
+    private static readonly DateTime Epoch = DateTime.UnixEpoch;
+
+    [Fact]
+    public void UpdatePositions_accumulates_parent_positions()
+    {
+        var calculator = new OrbitalCalculator();
+        calculator.AddBody(Root(0));
+        calculator.AddBody(OrbitingBody(1, 0, semiMajorAxisMeters: 1_000));
+        calculator.AddBody(OrbitingBody(2, 1, semiMajorAxisMeters: 100));
+
+        calculator.UpdatePositions(Epoch);
+
+        Assert.True(calculator.HasValidPosition(2));
+        double expectedLightSeconds = 1.1 / 299_792.458;
+        Assert.Equal(expectedLightSeconds, calculator.GetDistanceLightSeconds(0, 2), precision: 12);
+    }
+
+    [Fact]
+    public void UpdatePositions_rejects_missing_parent_and_non_elliptical_orbits()
+    {
+        var calculator = new OrbitalCalculator();
+        calculator.AddBody(Root(0));
+        calculator.AddBody(OrbitingBody(1, 99, semiMajorAxisMeters: 1_000));
+        calculator.AddBody(OrbitingBody(2, 0, semiMajorAxisMeters: 1_000, eccentricity: 1));
+
+        calculator.UpdatePositions(Epoch);
+
+        Assert.False(calculator.HasValidPosition(1));
+        Assert.False(calculator.HasValidPosition(2));
+        Assert.True(double.IsPositiveInfinity(calculator.GetDistanceLightSeconds(0, 1)));
+    }
+
+    [Fact]
+    public void InferParentIds_recovers_nested_barycentre_relationships()
+    {
+        var bodies = new[]
+        {
+            (BodyId: 54, ParentChain: (IReadOnlyList<int>)new[] { 48, 47, 1, 0 }),
+            (BodyId: 55, ParentChain: (IReadOnlyList<int>)new[] { 48, 47, 1, 0 }),
+        };
+
+        var parents = OrbitalHierarchy.InferParentIds(bodies);
+
+        Assert.Equal(48, parents[54]);
+        Assert.Equal(47, parents[48]);
+        Assert.Equal(1, parents[47]);
+        Assert.Equal(0, parents[1]);
+    }
+
+    [Fact]
+    public void IsSystemRoot_accepts_a_root_barycentre_but_not_an_orbiting_one()
+    {
+        Assert.True(OrbitalHierarchy.IsSystemRoot(-1, isMainStar: false, isBarycentre: true));
+        Assert.False(OrbitalHierarchy.IsSystemRoot(0, isMainStar: false, isBarycentre: true));
+    }
+
+    [Fact]
+    public void OptimizeRoute_finds_the_shortest_open_path_and_removes_duplicates()
+    {
+        var calculator = CalculatorWithFixedPositions(0, 1, 2, 3);
+
+        var route = RouteOptimizer.OptimizeRoute(0, new List<int> { 3, 1, 2, 2 }, calculator);
+
+        Assert.Equal(new[] { 0, 1, 2, 3 }, route);
+    }
+
+    [Fact]
+    public void OptimizeRoute_returns_empty_when_any_required_position_is_invalid()
+    {
+        var calculator = CalculatorWithFixedPositions(0, 1);
+        calculator.AddBody(new OrbitalCalculator.OrbitalBody { BodyId = 2, Name = "invalid" });
+
+        var route = RouteOptimizer.OptimizeRoute(0, new List<int> { 1, 2 }, calculator);
+
+        Assert.Empty(route);
+    }
+
+    [Fact]
+    public void OptimizeRoute_heuristic_keeps_every_target()
+    {
+        var ids = Enumerable.Range(0, 18).ToArray();
+        var calculator = CalculatorWithFixedPositions(ids);
+
+        var route = RouteOptimizer.OptimizeRoute(0, ids.Skip(1).Reverse().ToList(), calculator);
+
+        Assert.Equal(18, route.Count);
+        Assert.Equal(0, route[0]);
+        Assert.Equal(ids.OrderBy(id => id), route.OrderBy(id => id));
+    }
+
+    [Fact]
+    public void OptimizeRoute_exact_solver_handles_fifteen_targets()
+    {
+        var ids = Enumerable.Range(0, 16).ToArray();
+        var calculator = CalculatorWithFixedPositions(ids);
+
+        var route = RouteOptimizer.OptimizeRoute(0, ids.Skip(1).Reverse().ToList(), calculator);
+
+        Assert.Equal(ids, route);
+    }
+
+    private static OrbitalCalculator CalculatorWithFixedPositions(params int[] ids)
+    {
+        var calculator = new OrbitalCalculator();
+        foreach (int id in ids)
+        {
+            calculator.AddBody(new OrbitalCalculator.OrbitalBody
+            {
+                BodyId = id,
+                Name = id.ToString(),
+                Position = new OrbitalCalculator.Vec3d(id, 0, 0),
+                PositionValid = true,
+            });
+        }
+        return calculator;
+    }
+
+    private static OrbitalCalculator.OrbitalBody Root(int id)
+        => new()
+        {
+            BodyId = id,
+            Name = "root",
+            IsRoot = true,
+        };
+
+    private static OrbitalCalculator.OrbitalBody OrbitingBody(
+        int id,
+        int parentId,
+        double semiMajorAxisMeters,
+        double eccentricity = 0)
+        => new()
+        {
+            BodyId = id,
+            Name = id.ToString(),
+            ParentId = parentId,
+            HasOrbitalElements = true,
+            SemiMajorAxis = semiMajorAxisMeters,
+            Eccentricity = eccentricity,
+            OrbitalPeriod = 1_000,
+            Epoch = Epoch,
+        };
+}

--- a/tests/SrvSurvey.OrbitalTests/SrvSurvey.OrbitalTests.csproj
+++ b/tests/SrvSurvey.OrbitalTests/SrvSurvey.OrbitalTests.csproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Include="..\..\SrvSurvey\game\OrbitalMechanics.cs" Link="OrbitalMechanics.cs" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
## Summary

This draft supersedes #884 by carrying the planet visit-order work onto the current `main`. It preserves @teal-bauer's original two commits and authorship, then adds a separate hardening commit based on the review discussion in #884.

- adds a **default-off** `Show optimized DSS route` setting around the route UI and calculation entry point
- uses one DSS target-selection path for both the existing display and the optimizer, including ring destinations
- reconstructs nested barycentre parents from journal parent chains and supports a root barycentre in multi-star systems
- rejects missing, cyclic, or invalid orbital data instead of treating incomplete bodies as if they were at the origin
- replaces factorial permutation search with exact Held-Karp optimization through 15 targets, then nearest-neighbor plus 2-opt for larger systems
- caches rendered routes briefly and invalidates them when new orbital scans arrive
- includes stack traces in route-calculation error logging
- adds focused regression and performance-boundary coverage to CI

## Review history

- Supersedes #884; that PR remains the source of the original implementation and review discussion.
- Continues the feature requested in #875.
- Spansh orbital enrichment is staged separately in [Fenris159/SrvSurvey#2](https://github.com/Fenris159/SrvSurvey/pull/2), based on this branch so its diff remains isolated.
- EDSM can provide supplemental static orbital metadata, but it cannot independently reconstruct current positions because its bodies API does not expose ascending node or mean anomaly.
- Manual route target editing and external-plugin target input remain follow-ups rather than blockers for this draft.

## Validation

- `dotnet test tests/SrvSurvey.OrbitalTests/SrvSurvey.OrbitalTests.csproj --configuration Release --no-restore` — 8 passed
- `dotnet build SrvSurvey/SrvSurvey.csproj --configuration Release --no-restore` — succeeded with 0 errors (existing repository warnings remain)

Runtime verification in Elite Dangerous is still needed for the final overlay layout and real journal-system coverage.
