### PR TITLE
Automatically remove sold exploration data from exploration estimates

### DIFF
--- a/SrvSurvey/Main.cs
+++ b/SrvSurvey/Main.cs
@@ -534,6 +534,7 @@ namespace SrvSurvey
             if (rslt == DialogResult.Yes)
             {
                 game.cmdr.explRewards = 0;
+                game.cmdr.explRewardsBySystem = null;
                 game.cmdr.countJumps = 0;
                 game.cmdr.distanceTravelled = 0;
                 game.cmdr.countScans = 0;

--- a/SrvSurvey/game/CommanderSettings.cs
+++ b/SrvSurvey/game/CommanderSettings.cs
@@ -160,8 +160,6 @@ namespace SrvSurvey.game
         public long organicRewards;
 
         public long explRewards;
-        [JsonProperty(NullValueHandling = NullValueHandling.Ignore, DefaultValueHandling = DefaultValueHandling.Ignore)]
-        public Dictionary<string, long>? explRewardsBySystem;
         public double distanceTravelled;
         public int countJumps;
         public int countScans;
@@ -203,6 +201,9 @@ namespace SrvSurvey.game
         [JsonProperty(NullValueHandling = NullValueHandling.Ignore, DefaultValueHandling = DefaultValueHandling.Ignore)]
         public int countRadicoidaUnica;
 
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore, DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public Dictionary<string, long>? explRewardsBySystem;
+
         #endregion
 
         public void applyExplReward(long reward, string reason, string systemName)
@@ -214,7 +215,7 @@ namespace SrvSurvey.game
             {
                 this.explRewardsBySystem ??= new Dictionary<string, long>(StringComparer.OrdinalIgnoreCase);
                 var trackedName = this.explRewardsBySystem.Keys.FirstOrDefault(name =>
-                    name.Equals(systemName, StringComparison.OrdinalIgnoreCase)) ?? systemName;
+                    name.like(systemName)) ?? systemName;
                 this.explRewardsBySystem[trackedName] = this.explRewardsBySystem.GetValueOrDefault(trackedName) + reward;
             }
 
@@ -240,7 +241,7 @@ namespace SrvSurvey.game
             foreach (var soldSystemName in soldSystemNames)
             {
                 var trackedName = this.explRewardsBySystem.Keys.FirstOrDefault(name =>
-                    name.Equals(soldSystemName, StringComparison.OrdinalIgnoreCase));
+                    name.like(soldSystemName));
                 if (trackedName == null || !this.explRewardsBySystem.Remove(trackedName, out var systemRewards))
                     continue;
 
@@ -257,7 +258,6 @@ namespace SrvSurvey.game
                 this.explRewardsBySystem = null;
 
             Game.log($"{eventName}: removed {deductedRewards.ToString("N0")} estimated exploration credits for {matchedSystems} sold system(s).");
-            PlotBase2.renderAll(Game.activeGame);
             this.Save();
             Game.activeGame?.fireUpdate(true);
         }

--- a/SrvSurvey/game/CommanderSettings.cs
+++ b/SrvSurvey/game/CommanderSettings.cs
@@ -160,6 +160,8 @@ namespace SrvSurvey.game
         public long organicRewards;
 
         public long explRewards;
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore, DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public Dictionary<string, long>? explRewardsBySystem;
         public double distanceTravelled;
         public int countJumps;
         public int countScans;
@@ -203,13 +205,61 @@ namespace SrvSurvey.game
 
         #endregion
 
-        public void applyExplReward(long reward, string reason)
+        public void applyExplReward(long reward, string reason, string systemName)
         {
             Game.log($"Gained: +{reward.ToString("N0")} for {reason}");
             this.explRewards += reward;
 
+            if (!string.IsNullOrWhiteSpace(systemName))
+            {
+                this.explRewardsBySystem ??= new Dictionary<string, long>(StringComparer.OrdinalIgnoreCase);
+                var trackedName = this.explRewardsBySystem.Keys.FirstOrDefault(name =>
+                    name.Equals(systemName, StringComparison.OrdinalIgnoreCase)) ?? systemName;
+                this.explRewardsBySystem[trackedName] = this.explRewardsBySystem.GetValueOrDefault(trackedName) + reward;
+            }
+
             PlotBase2.renderAll(Game.activeGame);
             this.Save();
+        }
+
+        public void removeSoldExplorationData(IEnumerable<string> systemNames, string eventName)
+        {
+            if (this.explRewardsBySystem == null || this.explRewardsBySystem.Count == 0)
+                return;
+
+            var soldSystemNames = systemNames
+                .Where(name => !string.IsNullOrWhiteSpace(name))
+                .Select(name => name.Trim())
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .ToList();
+            if (soldSystemNames.Count == 0)
+                return;
+
+            long removedRewards = 0;
+            var matchedSystems = 0;
+            foreach (var soldSystemName in soldSystemNames)
+            {
+                var trackedName = this.explRewardsBySystem.Keys.FirstOrDefault(name =>
+                    name.Equals(soldSystemName, StringComparison.OrdinalIgnoreCase));
+                if (trackedName == null || !this.explRewardsBySystem.Remove(trackedName, out var systemRewards))
+                    continue;
+
+                removedRewards += systemRewards;
+                matchedSystems++;
+            }
+
+            if (matchedSystems == 0)
+                return;
+
+            var deductedRewards = Math.Min(this.explRewards, removedRewards);
+            this.explRewards -= deductedRewards;
+            if (this.explRewardsBySystem.Count == 0)
+                this.explRewardsBySystem = null;
+
+            Game.log($"{eventName}: removed {deductedRewards.ToString("N0")} estimated exploration credits for {matchedSystems} sold system(s).");
+            PlotBase2.renderAll(Game.activeGame);
+            this.Save();
+            Game.activeGame?.fireUpdate(true);
         }
 
         public void setMarketId(long newMarketId, string text)

--- a/SrvSurvey/game/Game.cs
+++ b/SrvSurvey/game/Game.cs
@@ -1110,6 +1110,21 @@ namespace SrvSurvey.game
                         eddn.onJournalEntry(this, (dynamic)entry, raw);
                 }
 
+                // Frontier emits these only after a Cartographics page has finished selling.
+                // Reconcile the local estimate independently of optional upload integrations.
+                if (entry is SellExplorationData sellExplorationData)
+                {
+                    var soldSystems = (sellExplorationData.Systems ?? new List<string>())
+                        .Concat(sellExplorationData.Discovered ?? new List<string>());
+                    this.cmdr.removeSoldExplorationData(soldSystems, sellExplorationData.@event);
+                }
+                else if (entry is MultiSellExplorationData multiSellExplorationData)
+                {
+                    var soldSystems = multiSellExplorationData.Discovered?
+                        .Select(system => system.SystemName) ?? Enumerable.Empty<string>();
+                    this.cmdr.removeSoldExplorationData(soldSystems, multiSellExplorationData.@event);
+                }
+
                 // finally, let active quests know about this
                 PlayState.current?.processJournalEntry(raw).justDoIt();
             }

--- a/SrvSurvey/game/Game.cs
+++ b/SrvSurvey/game/Game.cs
@@ -1110,21 +1110,6 @@ namespace SrvSurvey.game
                         eddn.onJournalEntry(this, (dynamic)entry, raw);
                 }
 
-                // Frontier emits these only after a Cartographics page has finished selling.
-                // Reconcile the local estimate independently of optional upload integrations.
-                if (entry is SellExplorationData sellExplorationData)
-                {
-                    var soldSystems = (sellExplorationData.Systems ?? new List<string>())
-                        .Concat(sellExplorationData.Discovered ?? new List<string>());
-                    this.cmdr.removeSoldExplorationData(soldSystems, sellExplorationData.@event);
-                }
-                else if (entry is MultiSellExplorationData multiSellExplorationData)
-                {
-                    var soldSystems = multiSellExplorationData.Discovered?
-                        .Select(system => system.SystemName) ?? Enumerable.Empty<string>();
-                    this.cmdr.removeSoldExplorationData(soldSystems, multiSellExplorationData.@event);
-                }
-
                 // finally, let active quests know about this
                 PlayState.current?.processJournalEntry(raw).justDoIt();
             }
@@ -3321,6 +3306,20 @@ namespace SrvSurvey.game
             // TODO: with new UX code, this should be just
             //// overlays may want to appear or render at this time
             //PlotBase2.renderAll(this);
+        }
+
+        private void onJournalEntry(SellExplorationData entry)
+        {
+            var soldSystems = (entry.Systems ?? new List<string>())
+                .Concat(entry.Discovered ?? new List<string>());
+            this.cmdr.removeSoldExplorationData(soldSystems, entry.@event);
+        }
+
+        private void onJournalEntry(MultiSellExplorationData entry)
+        {
+            var soldSystems = entry.Discovered?
+                .Select(system => system.SystemName) ?? Enumerable.Empty<string>();
+            this.cmdr.removeSoldExplorationData(soldSystems, entry.@event);
         }
 
         private void onJournalEntry(SellOrganicData entry)

--- a/SrvSurvey/game/SystemData.cs
+++ b/SrvSurvey/game/SystemData.cs
@@ -732,7 +732,7 @@ namespace SrvSurvey.game
                 {
                     body.reward = reward;
                     game.cmdr.countScans += 1;
-                    game.cmdr.applyExplReward(reward, $"Scan:{entry.ScanType} of {entry.BodyName}");
+                    game.cmdr.applyExplReward(reward, $"Scan:{entry.ScanType} of {entry.BodyName}", this.name);
 
                     // and adjust main star value too
                     if (this.honked)
@@ -880,7 +880,7 @@ namespace SrvSurvey.game
                 {
                     body.reward = reward;
                     Game.activeGame.cmdr.countDSS += 1;
-                    Game.activeGame.cmdr.applyExplReward(reward, $"DSS of {body.name}");
+                    Game.activeGame.cmdr.applyExplReward(reward, $"DSS of {body.name}", this.name);
                 }
             }
 
@@ -892,7 +892,7 @@ namespace SrvSurvey.game
                 if (Game.activeGame?.systemData == this)
                 {
                     var bonus = countMappableBodies * 10_000;
-                    Game.activeGame.cmdr.applyExplReward(bonus, $"DSS mapped all valid bodies");
+                    Game.activeGame.cmdr.applyExplReward(bonus, $"DSS mapped all valid bodies", this.name);
                 }
             }
 


### PR DESCRIPTION
## Summary

- Persist estimated exploration rewards by star system while retaining the existing aggregate shown on the main window.
- Consume `SellExplorationData` and `MultiSellExplorationData` after the completed journal event has passed through normal local processing.
- Remove only matched sold systems from the unsold estimate, page by page, and refresh the main-window value immediately.
- Keep sale handling idempotent and clear the per-system ledger through the existing manual exploration reset.

## Why

The exploration trip counter previously accumulated estimated scan value but could not identify which systems contributed to it. Universal Cartographics sells data page by page, so the local estimate remained unchanged after individual systems were sold.

This change records each system's contribution and uses the system names supplied by Frontier's completed sale events to subtract only the sold data.

## Behavior and compatibility

- Historical per-system scan files are not deleted or modified.
- Selling data changes only the estimated reward total; jump, distance, scan, DSS, and landing trip statistics remain intact.
- Duplicate or replayed sale events cannot deduct the same tracked system twice.
- Existing aggregate rewards recorded before this change have no system attribution. Automatic deductions apply to rewards tracked after this version or after the commander next uses the existing manual reset.

## Checks

- `git -c core.whitespace=cr-at-eol diff upstream/main...origin/exploration-sold-data-tracking --check` passed.
- `dotnet build SrvSurvey/SrvSurvey.csproj` succeeded with 0 errors and the repository's existing warnings.
