### PR TITLE
Cache Fileheader journal entry + disambiguate `isOdyssey`

### DIFF
--- a/SrvSurvey/Util.cs
+++ b/SrvSurvey/Util.cs
@@ -640,7 +640,8 @@ static class Util
         Program.defer(() => fadeNext(form, targetOpacity, lastTick, delta));
     }
 
-    public static bool isOdyssey = Game.activeGame?.journals == null || Game.activeGame.journals.isOdyssey;
+    /// <summary> Returns true if we are operating from a Live/Odyssey journal, or false if this from a Legacy journal </summary>
+    public static bool isOdyssey = Game.activeGame?.journals == null || !Game.activeGame.journals.isLegacy;
 
     public static int GetBodyValue(Scan scan, bool cmdrMapped)
     {

--- a/SrvSurvey/forms/FormPostProcess.cs
+++ b/SrvSurvey/forms/FormPostProcess.cs
@@ -266,7 +266,7 @@ namespace SrvSurvey
                         countCargoTransferredTB = countCargoTransferred;
                     }
 
-                    if (journal.isOdyssey)
+                    if (!journal.isLegacy)
                     {
                         // if Odyssey ... process all exploration events
                         SystemData? sysData = null;

--- a/SrvSurvey/game/CommanderSettings.cs
+++ b/SrvSurvey/game/CommanderSettings.cs
@@ -123,10 +123,10 @@ namespace SrvSurvey.game
             journalFiles.Find((filepath) =>
             {
                 var journal = new JournalFile(filepath);
-                if (journal.isOdyssey && !string.IsNullOrEmpty(journal.cmdrName) && !string.IsNullOrEmpty(journal.cmdrFid))
+                if (!journal.isLegacy && !string.IsNullOrEmpty(journal.cmdrName) && !string.IsNullOrEmpty(journal.cmdrFid))
                 {
                     // create and save settings for this Cmdr
-                    var cmdrSettings = CommanderSettings.Load(journal.cmdrFid, journal.isOdyssey, journal.cmdrName);
+                    var cmdrSettings = CommanderSettings.Load(journal.cmdrFid, !journal.isLegacy, journal.cmdrName);
                     cmdrSettings.Save();
                     return true;
                 }

--- a/SrvSurvey/game/Game.cs
+++ b/SrvSurvey/game/Game.cs
@@ -229,11 +229,6 @@ namespace SrvSurvey.game
 
             log($"Cmdr loaded: {this.Commander != null}");
 
-            // Reconstruct Inara's current-session state without uploading journal history.
-            // This must happen before live journal callbacks begin so credits and inventory
-            // have an authoritative baseline when the first new event is processed.
-            this.inara = Inara.Create(this);
-
             // now listen for changes
             this.journals.onJournalEntry += Journals_onJournalEntry;
             this.status.StatusChanged += Status_StatusChanged;
@@ -625,11 +620,7 @@ namespace SrvSurvey.game
                 log($"Game.initializeFromJournal: USING {this.Commander} (FID:{this.fid}), journals.Count:{journals?.Count}");
 
                 // set EDDN upload header
-                if (journals?.Entries.Count > 0)
-                {
-                    var gameFileHeader = (Fileheader)journals.Entries.First();
-                    EDDN.header = new UploadPayloadHeader(loadEntry.Commander, gameFileHeader.gameversion, gameFileHeader.build);
-                }
+                EDDN.header = new UploadPayloadHeader(loadEntry.Commander, journals!.fileheader!.gameversion, journals.fileheader.build);
             }
 
             // exit early if we are shutdown
@@ -644,7 +635,7 @@ namespace SrvSurvey.game
             if (loadEntry != null)
             {
                 // How much does it matter that v4-live/Horizons acts just like Odyssey?
-                this.cmdr = CommanderSettings.Load(loadEntry.FID, journals.isOdyssey, loadEntry.Commander);
+                this.cmdr = CommanderSettings.Load(loadEntry.FID, !journals.isLegacy, loadEntry.Commander);
                 this.cmdrCodex = cmdr.loadCodex();
                 this.cmdrColony = ColonyData.Load(loadEntry.FID, loadEntry.Commander);
                 // Maybe? Game.ready = true;
@@ -729,6 +720,15 @@ namespace SrvSurvey.game
 
                 if (this.status.PlanetRadius > 0 && this.status.PlanetRadius != cmdr.currentBodyRadius)
                     log($"Oops - bad systemBody ?!");
+
+                // do not upload non-Live data to Inara
+                if (!journals.isLegacy)
+                {
+                    // Reconstruct Inara's current-session state without uploading journal history.
+                    // This must happen before live journal callbacks begin so credits and inventory
+                    // have an authoritative baseline when the first new event is processed.
+                    this.inara = Inara.Create(this);
+                }
 
                 log($"Game.initializeFromJournal: system: '{cmdr.currentSystem}' (id:{cmdr.currentSystemAddress}), body: '{this.systemBody?.name}' (id:{this.systemBody?.id}, r: {Util.metersToString(this.systemBody?.radius ?? -1)})");
             }

--- a/SrvSurvey/game/JournalFile.cs
+++ b/SrvSurvey/game/JournalFile.cs
@@ -32,11 +32,16 @@ namespace SrvSurvey
         protected StreamReader reader;
         public readonly string filepath;
         public readonly DateTime timestamp;
+        public Fileheader? fileheader { get; private set; }
+        public LoadGame? lastLoadGame { get; private set; }
         public string? cmdrName { get; private set; }
         public string? cmdrFid { get; private set; }
-        public readonly bool isOdyssey;
-        public bool? isGameOdyssey;
-        public bool? isGameHorizons;
+        /// <summary> Returns true if this is from a Legacy journal, or false if this from a Live/Odyssey journal. Assumes NOT legacy if we don't have the Fileheader line yet. </summary>
+        public bool isLegacy => this.fileheader?.Odyssey == false;
+        /// <summary> Returns true the player paid for the Odyssey DLC </summary>
+        public bool isGameOdyssey => this.lastLoadGame?.Odyssey ?? false;
+        /// <summary> Returns true the player has the Horizons expension (which I think everyone does now) </summary>
+        public bool isGameHorizons => this.lastLoadGame?.Horizons ?? false;
 
         public bool isShutdown { get; private set; }
 
@@ -50,14 +55,6 @@ namespace SrvSurvey
             this.reader = Data.openSharedStreamReader(filepath);
 
             this.readEntries(targetFID);
-
-
-            // assume Odyssey if we don't have the Fileheader line yet.
-            this.isOdyssey = true;
-            if (this.Entries.FirstOrDefault() is Fileheader entryFileHeader)
-                this.isOdyssey = entryFileHeader.Odyssey;
-            //else
-            //    Debugger.Break(); // This happens when at the main menu before loading any cmdr
         }
 
         public void Dispose()
@@ -81,7 +78,7 @@ namespace SrvSurvey
         {
             while (this.reader?.EndOfStream == false)
             {
-                var (entry , raw)= this.readEntry();
+                var (entry, raw) = this.readEntry();
 
                 // stop early if not target cmdr
                 if (targetFID != null && entry is Commander && ((Commander)entry).FID != targetFID)
@@ -97,6 +94,18 @@ namespace SrvSurvey
             if (entry != null)
             {
                 this.Entries.Add(entry);
+
+                // keep hold of this for future reference
+                if (entry is Fileheader entryFileheader)
+                {
+                    if (this.fileheader != null)
+                    {
+                        Game.log("Why is there another Fileheader?");
+                        Debugger.Break();
+                    }
+                    this.fileheader = entryFileheader;
+                }
+
                 if (entry.@event == nameof(Shutdown) && !Program.useLastIfShutdown) this.isShutdown = true;
 
                 if (this.cmdrName == null && entry.@event == nameof(Commander))
@@ -106,11 +115,9 @@ namespace SrvSurvey
                     this.cmdrFid = commanderEntry.FID;
                 }
 
+                // keep hold of this for future reference
                 if (entry is LoadGame entryLoadGame)
-                {
-                    this.isGameOdyssey = entryLoadGame.Odyssey;
-                    this.isGameHorizons = entryLoadGame.Horizons;
-                }
+                    this.lastLoadGame = entryLoadGame;
             }
 
             return (entry, raw);
@@ -212,7 +219,7 @@ namespace SrvSurvey
                     if (finished) break;
                 }
 
-                var priorFilepath = JournalFile.getSiblingCommanderJournal(this.cmdrName, this.isOdyssey, journal.timestamp, this.cmdrFid);
+                var priorFilepath = JournalFile.getSiblingCommanderJournal(this.cmdrName, !this.isLegacy, journal.timestamp, this.cmdrFid);
                 journal = priorFilepath == null ? null : new JournalFile(priorFilepath);
             }
             ;
@@ -243,7 +250,7 @@ namespace SrvSurvey
                     if (finished) break;
                 }
 
-                priorFilepath = JournalFile.getSiblingCommanderJournal(this.cmdrName, this.isOdyssey, journal.timestamp, this.cmdrFid, searchUp);
+                priorFilepath = JournalFile.getSiblingCommanderJournal(this.cmdrName, !this.isLegacy, journal.timestamp, this.cmdrFid, searchUp);
                 if (priorFilepath != null)
                     journal = new JournalFile(priorFilepath);
 

--- a/SrvSurvey/net/EDDN.cs
+++ b/SrvSurvey/net/EDDN.cs
@@ -110,8 +110,8 @@ namespace SrvSurvey.net
             // augment
             message["StarSystem"] = raw.Value<string>("System");
             message["StarPos"] = new JArray(game.systemData.starPos);
-            if (game.journals.isGameOdyssey.HasValue) message["odyssey"] = game.journals.isGameOdyssey.Value;
-            if (game.journals.isGameHorizons.HasValue) message["horizons"] = game.journals.isGameHorizons.Value;
+            if (game.journals.isGameOdyssey) message["odyssey"] = game.journals.isGameOdyssey;
+            if (game.journals.isGameHorizons) message["horizons"] = game.journals.isGameHorizons;
 
             // Only set body name/ID if status.json has a BodyName and it matches the body we are tracking ...
             if (game.status.BodyName != null && game.systemBody != null && game.status.BodyName == game.systemBody.name)
@@ -139,8 +139,8 @@ namespace SrvSurvey.net
             // augment
             message["StarSystem"] = game.systemData.name;
             message["StarPos"] = new JArray(game.systemData.starPos);
-            if (game.journals.isGameOdyssey.HasValue) message["odyssey"] = game.journals.isGameOdyssey.Value;
-            if (game.journals.isGameHorizons.HasValue) message["horizons"] = game.journals.isGameHorizons.Value;
+            if (game.journals.isGameOdyssey) message["odyssey"] = game.journals.isGameOdyssey;
+            if (game.journals.isGameHorizons) message["horizons"] = game.journals.isGameHorizons;
 
             upload(message, "https://eddn.edcd.io/schemas/approachsettlement/1").justDoIt();
         }
@@ -180,8 +180,8 @@ namespace SrvSurvey.net
             var message = new JObject(raw);
 
             // augment
-            if (game.journals.isGameOdyssey.HasValue) message["odyssey"] = game.journals.isGameOdyssey.Value;
-            if (game.journals.isGameHorizons.HasValue) message["horizons"] = game.journals.isGameHorizons.Value;
+            if (game.journals.isGameOdyssey) message["odyssey"] = game.journals.isGameOdyssey;
+            if (game.journals.isGameHorizons) message["horizons"] = game.journals.isGameHorizons;
 
             upload(message, "https://eddn.edcd.io/schemas/dockinggranted/1").justDoIt();
         }
@@ -194,8 +194,8 @@ namespace SrvSurvey.net
             var message = new JObject(raw);
 
             // augment
-            if (game.journals.isGameOdyssey.HasValue) message["odyssey"] = game.journals.isGameOdyssey.Value;
-            if (game.journals.isGameHorizons.HasValue) message["horizons"] = game.journals.isGameHorizons.Value;
+            if (game.journals.isGameOdyssey) message["odyssey"] = game.journals.isGameOdyssey;
+            if (game.journals.isGameHorizons) message["horizons"] = game.journals.isGameHorizons;
 
             upload(message, "https://eddn.edcd.io/schemas/dockingdenied/1").justDoIt();
         }
@@ -209,8 +209,8 @@ namespace SrvSurvey.net
 
             // augment
             message["StarPos"] = new JArray(game.systemData.starPos);
-            if (game.journals.isGameOdyssey.HasValue) message["odyssey"] = game.journals.isGameOdyssey.Value;
-            if (game.journals.isGameHorizons.HasValue) message["horizons"] = game.journals.isGameHorizons.Value;
+            if (game.journals.isGameOdyssey) message["odyssey"] = game.journals.isGameOdyssey;
+            if (game.journals.isGameHorizons) message["horizons"] = game.journals.isGameHorizons;
 
             upload(message, "https://eddn.edcd.io/schemas/fssallbodiesfound/1").justDoIt();
         }
@@ -228,8 +228,8 @@ namespace SrvSurvey.net
             // augment
             message["StarSystem"] = game.systemData.name;
             message["StarPos"] = new JArray(game.systemData.starPos);
-            if (game.journals.isGameOdyssey.HasValue) message["odyssey"] = game.journals.isGameOdyssey.Value;
-            if (game.journals.isGameHorizons.HasValue) message["horizons"] = game.journals.isGameHorizons.Value;
+            if (game.journals.isGameOdyssey) message["odyssey"] = game.journals.isGameOdyssey;
+            if (game.journals.isGameHorizons) message["horizons"] = game.journals.isGameHorizons;
 
             upload(message, "https://eddn.edcd.io/schemas/fssbodysignals/1").justDoIt();
         }
@@ -246,8 +246,8 @@ namespace SrvSurvey.net
 
             // augment
             message["StarPos"] = new JArray(game.systemData.starPos);
-            if (game.journals.isGameOdyssey.HasValue) message["odyssey"] = game.journals.isGameOdyssey.Value;
-            if (game.journals.isGameHorizons.HasValue) message["horizons"] = game.journals.isGameHorizons.Value;
+            if (game.journals.isGameOdyssey) message["odyssey"] = game.journals.isGameOdyssey;
+            if (game.journals.isGameHorizons) message["horizons"] = game.journals.isGameHorizons;
 
             upload(message, "https://eddn.edcd.io/schemas/fssdiscoveryscan/1").justDoIt();
         }
@@ -282,8 +282,8 @@ namespace SrvSurvey.net
             // augment
             message["StarSystem"] = game.systemData.name;
             message["StarPos"] = new JArray(game.systemData.starPos);
-            if (game.journals.isGameOdyssey.HasValue) message["odyssey"] = game.journals.isGameOdyssey.Value;
-            if (game.journals.isGameHorizons.HasValue) message["horizons"] = game.journals.isGameHorizons.Value;
+            if (game.journals.isGameOdyssey) message["odyssey"] = game.journals.isGameOdyssey;
+            if (game.journals.isGameHorizons) message["horizons"] = game.journals.isGameHorizons;
 
             upload(message, "https://eddn.edcd.io/schemas/navbeaconscan/1").justDoIt();
         }
@@ -296,8 +296,8 @@ namespace SrvSurvey.net
             var message = new JObject(raw);
 
             // augment
-            if (game.journals.isGameOdyssey.HasValue) message["odyssey"] = game.journals.isGameOdyssey.Value;
-            if (game.journals.isGameHorizons.HasValue) message["horizons"] = game.journals.isGameHorizons.Value;
+            if (game.journals.isGameOdyssey) message["odyssey"] = game.journals.isGameOdyssey;
+            if (game.journals.isGameHorizons) message["horizons"] = game.journals.isGameHorizons;
 
             upload(message, "https://eddn.edcd.io/schemas/navroute/1").justDoIt();
         }
@@ -315,8 +315,8 @@ namespace SrvSurvey.net
 
             // augment
             message["StarPos"] = new JArray(game.systemData.starPos);
-            if (game.journals.isGameOdyssey.HasValue) message["odyssey"] = game.journals.isGameOdyssey.Value;
-            if (game.journals.isGameHorizons.HasValue) message["horizons"] = game.journals.isGameHorizons.Value;
+            if (game.journals.isGameOdyssey) message["odyssey"] = game.journals.isGameOdyssey;
+            if (game.journals.isGameHorizons) message["horizons"] = game.journals.isGameHorizons;
 
             upload(message, "https://eddn.edcd.io/schemas/scanbarycentre/1").justDoIt();
         }
@@ -336,8 +336,8 @@ namespace SrvSurvey.net
 
             // augment
             message["StarPos"] = new JArray(game.systemData.starPos);
-            if (game.journals.isGameOdyssey.HasValue) message["odyssey"] = game.journals.isGameOdyssey.Value;
-            if (game.journals.isGameHorizons.HasValue) message["horizons"] = game.journals.isGameHorizons.Value;
+            if (game.journals.isGameOdyssey) message["odyssey"] = game.journals.isGameOdyssey;
+            if (game.journals.isGameHorizons) message["horizons"] = game.journals.isGameHorizons;
 
             upload(message, "https://eddn.edcd.io/schemas/journal/1").justDoIt();
         }
@@ -353,8 +353,8 @@ namespace SrvSurvey.net
             trim(message, "*_Localised", "Wanted", nameof(FSDJump.BoostUsed), nameof(FSDJump.FuelLevel), nameof(FSDJump.FuelUsed), nameof(FSDJump.JumpDist), "HappiestSystem", "HomeSystem", nameof(SystemFaction.MyReputation), "SquadronFaction");
 
             // augment
-            if (game.journals.isGameOdyssey.HasValue) message["odyssey"] = game.journals.isGameOdyssey.Value;
-            if (game.journals.isGameHorizons.HasValue) message["horizons"] = game.journals.isGameHorizons.Value;
+            if (game.journals.isGameOdyssey) message["odyssey"] = game.journals.isGameOdyssey;
+            if (game.journals.isGameHorizons) message["horizons"] = game.journals.isGameHorizons;
 
             upload(message, "https://eddn.edcd.io/schemas/journal/1").justDoIt();
         }
@@ -370,8 +370,8 @@ namespace SrvSurvey.net
             trim(message, "*_Localised", "Wanted", nameof(FSDJump.BoostUsed), nameof(FSDJump.FuelLevel), nameof(FSDJump.FuelUsed), nameof(FSDJump.JumpDist), "HappiestSystem", "HomeSystem", nameof(SystemFaction.MyReputation), "SquadronFaction");
 
             // augment
-            if (game.journals.isGameOdyssey.HasValue) message["odyssey"] = game.journals.isGameOdyssey.Value;
-            if (game.journals.isGameHorizons.HasValue) message["horizons"] = game.journals.isGameHorizons.Value;
+            if (game.journals.isGameOdyssey) message["odyssey"] = game.journals.isGameOdyssey;
+            if (game.journals.isGameHorizons) message["horizons"] = game.journals.isGameHorizons;
 
             upload(message, "https://eddn.edcd.io/schemas/journal/1").justDoIt();
         }
@@ -388,8 +388,8 @@ namespace SrvSurvey.net
 
             // augment
             message["StarPos"] = new JArray(game.systemData.starPos);
-            if (game.journals.isGameOdyssey.HasValue) message["odyssey"] = game.journals.isGameOdyssey.Value;
-            if (game.journals.isGameHorizons.HasValue) message["horizons"] = game.journals.isGameHorizons.Value;
+            if (game.journals.isGameOdyssey) message["odyssey"] = game.journals.isGameOdyssey;
+            if (game.journals.isGameHorizons) message["horizons"] = game.journals.isGameHorizons;
 
             upload(message, "https://eddn.edcd.io/schemas/journal/1").justDoIt();
         }
@@ -405,8 +405,8 @@ namespace SrvSurvey.net
             trim(message, "*_Localised", "Wanted", nameof(Location.Latitude), nameof(Location.Longitude), "HappiestSystem", "HomeSystem", nameof(SystemFaction.MyReputation), "SquadronFaction");
 
             // augment
-            if (game.journals.isGameOdyssey.HasValue) message["odyssey"] = game.journals.isGameOdyssey.Value;
-            if (game.journals.isGameHorizons.HasValue) message["horizons"] = game.journals.isGameHorizons.Value;
+            if (game.journals.isGameOdyssey) message["odyssey"] = game.journals.isGameOdyssey;
+            if (game.journals.isGameHorizons) message["horizons"] = game.journals.isGameHorizons;
 
             upload(message, "https://eddn.edcd.io/schemas/journal/1").justDoIt();
         }
@@ -424,8 +424,8 @@ namespace SrvSurvey.net
             // augment
             message["StarSystem"] = game.systemData.name;
             message["StarPos"] = new JArray(game.systemData.starPos);
-            if (game.journals.isGameOdyssey.HasValue) message["odyssey"] = game.journals.isGameOdyssey.Value;
-            if (game.journals.isGameHorizons.HasValue) message["horizons"] = game.journals.isGameHorizons.Value;
+            if (game.journals.isGameOdyssey) message["odyssey"] = game.journals.isGameOdyssey;
+            if (game.journals.isGameHorizons) message["horizons"] = game.journals.isGameHorizons;
 
             upload(message, "https://eddn.edcd.io/schemas/journal/1").justDoIt();
         }

--- a/SrvSurvey/net/Inara.cs
+++ b/SrvSurvey/net/Inara.cs
@@ -67,11 +67,11 @@ namespace SrvSurvey.net
                 if (string.IsNullOrWhiteSpace(filepath))
                     throw new InvalidOperationException("The initialized game has no journal filepath.");
 
-                var fileheader = game.journals?.Entries.FirstOrDefault() as Fileheader;
+                var fileheader = game.journals?.fileheader;
                 if (fileheader == null)
                     throw new InvalidOperationException("The initialized game journal does not start with Fileheader.");
 
-                var session = InaraSession.Create(game.cmdr, fileheader.gameversion, game.journals?.isOdyssey == true);
+                var session = InaraSession.Create(game.cmdr, fileheader.gameversion, fileheader.Odyssey);
                 if (session == null)
                     throw new InvalidOperationException("The initialized game has no commander name, Frontier ID, or game version.");
 

--- a/SrvSurvey/net/InaraEventMapper.cs
+++ b/SrvSurvey/net/InaraEventMapper.cs
@@ -246,7 +246,7 @@ namespace SrvSurvey.net
                 InMulticrew = false;
             else if (name is "JoinACrew" or "ChangeCrewRole")
                 InMulticrew = true;
-            else if (entry.Value<bool?>("Multicrew") == true)
+            else if (entry["Multicrew"]?.Type == JTokenType.Boolean && entry["Multicrew"]?.Value<bool?>() == true)
                 InMulticrew = true;
             else if (name == "LoadGame")
                 InMulticrew = false;


### PR DESCRIPTION
- Cache the instance of `Fileheader` and the last `Loadgame` journal entries in JournalFile.cs. Use these to know the Odyssey'ness of things.
- Replace `JournalFile.isOdyssey` with `.isLegacy` ... to represent the difference between Live(Odyssey) and Legacy journal files. This removes ambiguity from `.isGameOdyssey` which repsents if a player paid for the Odyssey DLC
- Skip initializing Inara tracking if we're processing a Legacy journal file
- Relocate where Inara tracking is initialized, to avoid it throwing and catching errors harmlessly