### PR TITLE
Add Guardian map marker alignment offsets

### DIFF
--- a/SrvSurvey.Tests/GuardianMapMarkerOffsetTests.cs
+++ b/SrvSurvey.Tests/GuardianMapMarkerOffsetTests.cs
@@ -1,0 +1,153 @@
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using SrvSurvey.game;
+using SrvSurvey.units;
+using Xunit;
+
+namespace SrvSurvey.Tests;
+
+public sealed class GuardianMapMarkerOffsetTests
+{
+    [Fact]
+    public void CalculatesSamePortableMapOffsetAsAvalonia()
+    {
+        var offset = GuardianMapMarkerOffsetCalculator.calculate(
+            new LatLong2(0d, 0d),
+            new LatLong2(0d, 90d),
+            siteHeading: 0,
+            planetRadiusMeters: 100);
+
+        Assert.Equal(-Math.PI * 50, offset.x, precision: 8);
+        Assert.Equal(0, offset.y, precision: 8);
+    }
+
+    [Fact]
+    public void RotatesPortableOffsetIntoLegacySurfaceCoordinates()
+    {
+        var offset = GuardianMapMarkerOffsetCalculator.toSurfaceCoordinates(
+            new GuardianMapMarkerOffset(0, 10),
+            siteHeading: 90);
+
+        Assert.Equal(10, offset.X, precision: 6);
+        Assert.Equal(0, offset.Y, precision: 6);
+    }
+
+    [Fact]
+    public void RepeatedCorrectionKeepsTheOriginalMapAlignment()
+    {
+        const double radius = 1_000_000;
+        var original = new LatLong2(10d, 20d);
+        var firstCorrection = new LatLong2(10.01, 20.02);
+        var secondCorrection = new LatLong2(10.02, 20.03);
+        var survey = createSurvey(original);
+
+        Assert.True(survey.correctMapAlignment(firstCorrection, radius));
+        Assert.True(survey.correctMapAlignment(secondCorrection, radius));
+
+        var expected = GuardianMapMarkerOffsetCalculator.calculate(
+            original,
+            secondCorrection,
+            survey.siteHeading,
+            radius);
+        Assert.InRange(
+            Math.Abs(expected.x - survey.mapMarkerOffset.x),
+            0,
+            0.1);
+        Assert.InRange(
+            Math.Abs(expected.y - survey.mapMarkerOffset.y),
+            0,
+            0.1);
+        Assert.Equal(secondCorrection, survey.location);
+    }
+
+    [Fact]
+    public void HeadingCorrectionKeepsTheSurfaceOffsetFixed()
+    {
+        const double radius = 1_000_000;
+        var survey = createSurvey(new LatLong2(10d, 20d));
+        survey.correctMapAlignment(new LatLong2(10.01, 20.02), radius);
+        var originalSurfaceOffset = GuardianMapMarkerOffsetCalculator
+            .toSurfaceCoordinates(
+                survey.mapMarkerOffset,
+                survey.siteHeading);
+
+        Assert.True(survey.correctSiteHeading(123));
+
+        var correctedSurfaceOffset = GuardianMapMarkerOffsetCalculator
+            .toSurfaceCoordinates(
+                survey.mapMarkerOffset,
+                survey.siteHeading);
+        Assert.InRange(
+            Math.Abs(originalSurfaceOffset.X - correctedSurfaceOffset.X),
+            0,
+            0.1);
+        Assert.InRange(
+            Math.Abs(originalSurfaceOffset.Y - correctedSurfaceOffset.Y),
+            0,
+            0.1);
+    }
+
+    [Fact]
+    public void SurveyJsonUsesAvaloniaCompatibleTopLevelMetadata()
+    {
+        var survey = createSurvey(new LatLong2(12.5, -44.25));
+        survey.mapMarkerOffset = new GuardianMapMarkerOffset(6.5, -3.25);
+        survey.localSiteId = 17;
+        survey.catalogBodyName = "Test System 3";
+        survey.starPos = [1.25, -2.5, 3.75];
+        survey.distanceToArrival = 456.5;
+
+        var json = JsonConvert.SerializeObject(survey);
+        var root = JObject.Parse(json);
+
+        var metadata = Assert.IsType<JObject>(root["mapMarkerOffset"]);
+        Assert.Equal(6.5, metadata["x"]!.Value<double>());
+        Assert.Equal(-3.25, metadata["y"]!.Value<double>());
+        Assert.Equal(17, root["localSiteId"]!.Value<int>());
+        Assert.Equal("Test System 3", root["catalogBodyName"]!.Value<string>());
+        Assert.Equal(3, Assert.IsType<JArray>(root["starPos"]).Count);
+        Assert.Equal(456.5, root["distanceToArrival"]!.Value<double>());
+        Assert.Null(root["body"]);
+
+        var roundTrip = JsonConvert.DeserializeObject<GuardianSiteData>(json)!;
+        Assert.Equal(survey.mapMarkerOffset, roundTrip.mapMarkerOffset);
+        Assert.Equal(survey.localSiteId, roundTrip.localSiteId);
+        Assert.Equal(survey.catalogBodyName, roundTrip.catalogBodyName);
+        Assert.Equal(survey.starPos, roundTrip.starPos);
+        Assert.Equal(survey.distanceToArrival, roundTrip.distanceToArrival);
+    }
+
+    [Fact]
+    public void SurveyJsonWithoutOffsetRemainsCompatible()
+    {
+        var survey = createSurvey(new LatLong2(12.5, -44.25));
+        var json = JsonConvert.SerializeObject(survey);
+
+        Assert.DoesNotContain("mapMarkerOffset", json);
+
+        var roundTrip = JsonConvert.DeserializeObject<GuardianSiteData>(json)!;
+        Assert.True(roundTrip.mapMarkerOffset.isEmpty);
+    }
+
+    private static GuardianSiteData createSurvey(LatLong2 location)
+    {
+        return new GuardianSiteData
+        {
+            name = "$Ancient_Tiny_001:#index=1;",
+            nameLocalised = "Guardian Structure",
+            commander = "Test Commander",
+            firstVisited = DateTimeOffset.Parse("2026-08-31T12:00:00Z"),
+            lastVisited = DateTimeOffset.Parse("2026-08-31T12:00:00Z"),
+            type = GuardianSiteData.SiteType.Unknown,
+            index = 1,
+            location = location,
+            systemAddress = 42,
+            systemName = "Test System",
+            bodyId = 3,
+            bodyName = "Test System 3",
+            siteHeading = 37,
+            relicTowerHeading = -1,
+            notes = string.Empty,
+        };
+    }
+}

--- a/SrvSurvey/Main.Designer.cs
+++ b/SrvSurvey/Main.Designer.cs
@@ -126,6 +126,7 @@ namespace SrvSurvey
             toolStripSeparator5 = new ToolStripSeparator();
             btnRuinsMap = new ToolStripMenuItem();
             btnRuinsOrigin = new ToolStripMenuItem();
+            btnCorrectGuardianMap = new ToolStripMenuItem();
             toolTip1 = new ToolTip(components);
             btnQuestComms = new DrawButton();
             notifyIcon = new NotifyIcon(components);
@@ -1144,10 +1145,10 @@ namespace SrvSurvey
             // 
             menuGuardians.BackColor = SystemColors.ControlLight;
             menuGuardians.Font = new Font("Segoe UI", 14.25F, FontStyle.Regular, GraphicsUnit.Point, 0);
-            menuGuardians.Items.AddRange(new ToolStripItem[] { btnGuardianThings, btnRuins, btnRamTah, toolStripSeparator5, btnRuinsMap, btnRuinsOrigin });
+            menuGuardians.Items.AddRange(new ToolStripItem[] { btnGuardianThings, btnRuins, btnRamTah, toolStripSeparator5, btnRuinsMap, btnRuinsOrigin, btnCorrectGuardianMap });
             menuGuardians.Name = "menuGuardians";
             menuGuardians.RenderMode = ToolStripRenderMode.System;
-            menuGuardians.Size = new Size(242, 200);
+            menuGuardians.Size = new Size(279, 238);
             menuGuardians.targetButton = btnGuardian;
             // 
             // btnGuardianThings
@@ -1195,6 +1196,14 @@ namespace SrvSurvey
             btnRuinsOrigin.Size = new Size(241, 38);
             btnRuinsOrigin.Text = "Aerial Assist";
             btnRuinsOrigin.Click += btnRuinsOrigin_Click;
+            //
+            // btnCorrectGuardianMap
+            //
+            btnCorrectGuardianMap.Name = "btnCorrectGuardianMap";
+            btnCorrectGuardianMap.Size = new Size(278, 38);
+            btnCorrectGuardianMap.Text = "Correct Map Alignment Here";
+            btnCorrectGuardianMap.ToolTipText = "Use the current latitude and longitude as the corrected site origin and shift the saved survey markers to match.";
+            btnCorrectGuardianMap.Click += btnCorrectGuardianMap_Click;
             // 
             // btnQuestComms
             // 
@@ -1424,6 +1433,7 @@ namespace SrvSurvey
         private ToolStripSeparator toolStripSeparator5;
         private ToolStripMenuItem btnRuinsMap;
         private ToolStripMenuItem btnRuinsOrigin;
+        private ToolStripMenuItem btnCorrectGuardianMap;
         private Button btnNextWindow;
         private ToolTip toolTip1;
         private ToolStripMenuItem menuPrimaryProject;

--- a/SrvSurvey/Main.cs
+++ b/SrvSurvey/Main.cs
@@ -742,6 +742,7 @@ namespace SrvSurvey
 
                 btnRuinsMap.Enabled = false;
                 btnRuinsOrigin.Enabled = false;
+                btnCorrectGuardianMap.Enabled = false;
             }
             else if (game.systemSite == null || game.systemBody == null || game.systemBody.settlements?.Count == 0)
             {
@@ -749,6 +750,7 @@ namespace SrvSurvey
                 //txtGuardianSite.Text = "";
                 btnRuinsMap.Enabled = false;
                 btnRuinsOrigin.Enabled = false;
+                btnCorrectGuardianMap.Enabled = false;
             }
 
             if (Game.settings.enableGuardianSites)
@@ -758,6 +760,7 @@ namespace SrvSurvey
                     var allowed = PlotGuardians.allowed(game);
                     btnRuinsMap.Enabled = game.systemSite.siteHeading != -1 && allowed;
                     btnRuinsOrigin.Enabled = game.systemSite.siteHeading != -1 && allowed;
+                    btnCorrectGuardianMap.Enabled = game.systemSite.siteHeading != -1 && allowed;
                 }
             }
         }
@@ -1251,6 +1254,49 @@ namespace SrvSurvey
         private void btnRuinsOrigin_Click(object sender, EventArgs e)
         {
             PlotGuardians.switchMode(Mode.origin);
+        }
+
+        private void btnCorrectGuardianMap_Click(object sender, EventArgs e)
+        {
+            var site = game?.systemSite;
+            var body = game?.systemBody;
+            if (site == null
+                || body == null
+                || site.siteHeading is < 0 or > 359
+                || game?.status?.hasLatLong != true
+                || body.radius <= 0)
+                return;
+
+            var correctedLocation = Status.here.clone();
+            if (site.location.Equals(correctedLocation))
+            {
+                MessageBox.Show(
+                    this,
+                    "The survey already uses the current latitude and longitude as its origin.",
+                    "Guardian Map Alignment",
+                    MessageBoxButtons.OK,
+                    MessageBoxIcon.Information);
+                return;
+            }
+
+            var answer = MessageBox.Show(
+                this,
+                $"Change this survey's origin from {site.location.Lat:N6}, {site.location.Long:N6} to the current position {correctedLocation.Lat:N6}, {correctedLocation.Long:N6}?\r\n\r\nAll saved map markers will be shifted by the same alignment correction. The offset is stored as top-level survey metadata so SrvSurvey Avalonia can use it too.",
+                "Correct Guardian Map Alignment",
+                MessageBoxButtons.YesNo,
+                MessageBoxIcon.Question,
+                MessageBoxDefaultButton.Button2);
+            if (answer != DialogResult.Yes)
+                return;
+
+            site.correctMapAlignment(
+                correctedLocation,
+                (double)body.radius);
+            site.Save();
+            PlotBase2.getPlotter<PlotGuardians>()?.refreshMapAlignment();
+            FormRuins.activeForm?.Invalidate(true);
+            Game.log(
+                $"Corrected Guardian map alignment to {correctedLocation}; marker offset: {site.mapMarkerOffset}");
         }
 
         #region screenshot manipulations

--- a/SrvSurvey/forms/FormRuins.cs
+++ b/SrvSurvey/forms/FormRuins.cs
@@ -454,9 +454,7 @@ namespace SrvSurvey
                 if (siteData?.obeliskGroups?.Count > 0 && (poi.type == POIType.obelisk || poi.type == POIType.brokeObelisk) && !siteData.obeliskGroups.Contains(poi.name[0])) continue;
 
                 // calculate render point for POI
-                var pt = (PointF)Util.rotateLine(
-                    360 - (decimal)poi.angle,
-                    poi.dist);
+                var pt = this.projectMapMarker(poi.angle, poi.dist);
 
                 // is this the closest POI?
                 var x = pt.X * this.scale - mPos.X - dragOffset.X;
@@ -766,13 +764,13 @@ namespace SrvSurvey
                 // skip obelisks in groups not in this site
                 if (siteData?.obeliskGroups.Contains(foo.Key[0]) == false) continue;
 
-                var angle = 180 - foo.Value.X;
-                var dist = foo.Value.Y;
-                var pt = (PointF)Util.rotateLine((decimal)angle, (decimal)dist);
+                var pt = this.projectMapMarker(
+                    (decimal)foo.Value.X,
+                    (decimal)foo.Value.Y);
 
-                //g.DrawLine(Pens.DarkBlue, 0,0, -pt.X, -pt.Y);
+                //g.DrawLine(Pens.DarkBlue, 0, 0, pt.X, pt.Y);
                 var sz = g.MeasureString(foo.Key, GameColors.fontBigBold);
-                g.DrawString(foo.Key, GameColors.fontBig, GameColors.brushDarkCyan, -pt.X - (sz.Width / 2) + 2, -pt.Y - (sz.Height / 2) + 2);
+                g.DrawString(foo.Key, GameColors.fontBig, GameColors.brushDarkCyan, pt.X - (sz.Width / 2) + 2, pt.Y - (sz.Height / 2) + 2);
             }
 
             // and draw all the POIs
@@ -786,9 +784,7 @@ namespace SrvSurvey
                 if (siteData?.obeliskGroups?.Count > 0 && (poi.type == POIType.obelisk || poi.type == POIType.brokeObelisk) && !siteData.obeliskGroups.Contains(poi.name[0])) continue;
 
                 // calculate render point for POI
-                var pt = (PointF)Util.rotateLine(
-                    360 - (decimal)poi.angle,
-                    poi.dist);
+                var pt = this.projectMapMarker(poi.angle, poi.dist);
 
                 // is this the closest POI?
                 var x = pt.X * this.scale - mousePos.X - dragOffset.X;
@@ -1050,9 +1046,7 @@ namespace SrvSurvey
                 //var deg = 180 - siteData.siteHeading - poi.angle;
                 //var pt = (PointF)Util.rotateLine(deg, poi.dist);
 
-                var pt = (PointF)Util.rotateLine(
-                    360 - (decimal)poi.angle,
-                    poi.dist);
+                var pt = this.projectMapMarker(poi.angle, poi.dist);
 
                 var cmp = siteData.components?.GetValueOrDefault(poi.name)?.items[0] ?? GComponent.unknown;
 
@@ -1075,6 +1069,12 @@ namespace SrvSurvey
                     }
                 });
             }
+        }
+
+        private PointF projectMapMarker(decimal angle, decimal distance)
+        {
+            var point = (PointF)Util.rotateLine(360 - angle, distance);
+            return this.siteData?.mapMarkerOffset.apply(point) ?? point;
         }
 
         private void drawLegend(Graphics g)

--- a/SrvSurvey/game/GuardianMapMarkerOffset.cs
+++ b/SrvSurvey/game/GuardianMapMarkerOffset.cs
@@ -1,0 +1,216 @@
+using SrvSurvey.units;
+
+namespace SrvSurvey.game
+{
+    internal readonly record struct GuardianMapMarkerOffset(double x, double y)
+    {
+        public bool isEmpty => x == 0 && y == 0;
+
+        public PointF apply(PointF point)
+        {
+            return new PointF(
+                point.X + (float)this.x,
+                point.Y + (float)this.y);
+        }
+    }
+
+    internal static class GuardianMapMarkerOffsetCalculator
+    {
+        public static GuardianMapMarkerOffset calculate(
+            LatLong2 alignmentOrigin,
+            LatLong2 correctedOrigin,
+            int siteHeading,
+            double planetRadiusMeters)
+        {
+            validateLocation(alignmentOrigin, nameof(alignmentOrigin));
+            validateLocation(correctedOrigin, nameof(correctedOrigin));
+            validateHeading(siteHeading);
+            validateRadius(planetRadiusMeters);
+
+            var distance = getDistance(
+                alignmentOrigin,
+                correctedOrigin,
+                planetRadiusMeters);
+            if (distance == 0)
+                return default;
+
+            var bearing = getBearing(alignmentOrigin, correctedOrigin);
+            var mapAngle = (bearing - siteHeading) * Math.PI / 180d;
+            return new GuardianMapMarkerOffset(
+                -Math.Sin(mapAngle) * distance,
+                Math.Cos(mapAngle) * distance);
+        }
+
+        public static PointF toSurfaceCoordinates(
+            GuardianMapMarkerOffset markerOffset,
+            int siteHeading)
+        {
+            validateHeading(siteHeading);
+
+            var radians = siteHeading * Math.PI / 180d;
+            return new PointF(
+                (float)((-markerOffset.x * Math.Cos(radians))
+                    + (markerOffset.y * Math.Sin(radians))),
+                (float)((-markerOffset.x * Math.Sin(radians))
+                    - (markerOffset.y * Math.Cos(radians))));
+        }
+
+        public static GuardianMapMarkerOffset rotateForHeading(
+            GuardianMapMarkerOffset markerOffset,
+            int oldSiteHeading,
+            int newSiteHeading)
+        {
+            validateHeading(oldSiteHeading);
+            validateHeading(newSiteHeading);
+
+            var oldRadians = oldSiteHeading * Math.PI / 180d;
+            var surfaceX = (-markerOffset.x * Math.Cos(oldRadians))
+                + (markerOffset.y * Math.Sin(oldRadians));
+            var surfaceY = (-markerOffset.x * Math.Sin(oldRadians))
+                - (markerOffset.y * Math.Cos(oldRadians));
+            var newRadians = newSiteHeading * Math.PI / 180d;
+            return new GuardianMapMarkerOffset(
+                (-surfaceX * Math.Cos(newRadians))
+                    - (surfaceY * Math.Sin(newRadians)),
+                (surfaceX * Math.Sin(newRadians))
+                    - (surfaceY * Math.Cos(newRadians)));
+        }
+
+        public static LatLong2 recoverAlignmentOrigin(
+            LatLong2 correctedOrigin,
+            GuardianMapMarkerOffset markerOffset,
+            int siteHeading,
+            double planetRadiusMeters)
+        {
+            validateLocation(correctedOrigin, nameof(correctedOrigin));
+            validateHeading(siteHeading);
+            validateRadius(planetRadiusMeters);
+
+            var distance = Math.Sqrt(
+                (markerOffset.x * markerOffset.x)
+                    + (markerOffset.y * markerOffset.y));
+            if (!double.IsFinite(distance))
+                throw new ArgumentOutOfRangeException(
+                    nameof(markerOffset),
+                    "The marker offset must contain finite coordinates.");
+
+            if (distance == 0)
+                return correctedOrigin.clone();
+
+            var mapAngle = Math.Atan2(-markerOffset.x, markerOffset.y);
+            var originalToCorrectedBearing = normalizeDegrees(
+                (mapAngle * 180d / Math.PI) + siteHeading);
+            return getDestination(
+                correctedOrigin,
+                normalizeDegrees(originalToCorrectedBearing + 180d),
+                distance,
+                planetRadiusMeters);
+        }
+
+        private static double getDistance(
+            LatLong2 first,
+            LatLong2 second,
+            double radius)
+        {
+            if (first.Equals(second))
+                return 0;
+
+            var firstLatitude = degreesToRadians((double)first.Lat);
+            var secondLatitude = degreesToRadians((double)second.Lat);
+            var longitudeDelta = degreesToRadians(
+                (double)second.Long - (double)first.Long);
+            var cosine = (Math.Sin(firstLatitude) * Math.Sin(secondLatitude))
+                + (Math.Cos(firstLatitude)
+                    * Math.Cos(secondLatitude)
+                    * Math.Cos(longitudeDelta));
+            return Math.Acos(Math.Clamp(cosine, -1d, 1d)) * radius;
+        }
+
+        private static double getBearing(LatLong2 origin, LatLong2 target)
+        {
+            if (origin.Equals(target))
+                return 0;
+
+            var originLatitude = degreesToRadians((double)origin.Lat);
+            var targetLatitude = degreesToRadians((double)target.Lat);
+            var longitudeDelta = degreesToRadians(
+                (double)target.Long - (double)origin.Long);
+            var y = Math.Sin(longitudeDelta) * Math.Cos(targetLatitude);
+            var x = (Math.Cos(originLatitude) * Math.Sin(targetLatitude))
+                - (Math.Sin(originLatitude)
+                    * Math.Cos(targetLatitude)
+                    * Math.Cos(longitudeDelta));
+            return normalizeDegrees(Math.Atan2(y, x) * 180d / Math.PI);
+        }
+
+        private static LatLong2 getDestination(
+            LatLong2 origin,
+            double bearingDegrees,
+            double distanceMeters,
+            double planetRadiusMeters)
+        {
+            var latitude = degreesToRadians((double)origin.Lat);
+            var longitude = degreesToRadians((double)origin.Long);
+            var bearing = degreesToRadians(bearingDegrees);
+            var angularDistance = distanceMeters / planetRadiusMeters;
+            var destinationLatitude = Math.Asin(
+                (Math.Sin(latitude) * Math.Cos(angularDistance))
+                    + (Math.Cos(latitude)
+                        * Math.Sin(angularDistance)
+                        * Math.Cos(bearing)));
+            var destinationLongitude = longitude + Math.Atan2(
+                Math.Sin(bearing)
+                    * Math.Sin(angularDistance)
+                    * Math.Cos(latitude),
+                Math.Cos(angularDistance)
+                    - (Math.Sin(latitude) * Math.Sin(destinationLatitude)));
+            return new LatLong2(
+                destinationLatitude * 180d / Math.PI,
+                ((destinationLongitude * 180d / Math.PI + 540d) % 360d)
+                    - 180d);
+        }
+
+        private static void validateHeading(int siteHeading)
+        {
+            if (siteHeading is < 0 or > 359)
+                throw new ArgumentOutOfRangeException(
+                    nameof(siteHeading),
+                    "The site heading must be between 0 and 359 degrees.");
+        }
+
+        private static void validateRadius(double planetRadiusMeters)
+        {
+            if (!double.IsFinite(planetRadiusMeters)
+                || planetRadiusMeters <= 0)
+                throw new ArgumentOutOfRangeException(
+                    nameof(planetRadiusMeters),
+                    "The body radius must be positive.");
+        }
+
+        private static void validateLocation(
+            LatLong2 location,
+            string parameterName)
+        {
+            ArgumentNullException.ThrowIfNull(location, parameterName);
+            var latitude = (double)location.Lat;
+            var longitude = (double)location.Long;
+            if (!double.IsFinite(latitude)
+                || latitude is < -90 or > 90
+                || !double.IsFinite(longitude)
+                || longitude is < -180 or > 180)
+                throw new ArgumentOutOfRangeException(
+                    parameterName,
+                    "Latitude must be between -90 and 90 and longitude between -180 and 180 degrees.");
+        }
+
+        private static double normalizeDegrees(double degrees)
+        {
+            return ((degrees % 360d) + 360d) % 360d;
+        }
+
+        private static double degreesToRadians(double degrees)
+        {
+            return degrees * Math.PI / 180d;
+        }
+    }
+}

--- a/SrvSurvey/game/GuardianSiteData.cs
+++ b/SrvSurvey/game/GuardianSiteData.cs
@@ -230,6 +230,11 @@ namespace SrvSurvey.game
         public SiteType type;
         public int index;
         public LatLong2 location;
+        public GuardianMapMarkerOffset mapMarkerOffset;
+        public int localSiteId;
+        public string? catalogBodyName;
+        public double[]? starPos;
+        public double? distanceToArrival;
         public long systemAddress;
         public string systemName;
         public int bodyId;
@@ -251,6 +256,49 @@ namespace SrvSurvey.game
         public List<SitePOI>? rawPoi;
 
         #endregion
+
+        public bool correctMapAlignment(
+            LatLong2 correctedLocation,
+            double planetRadiusMeters)
+        {
+            if (this.location.Equals(correctedLocation))
+                return false;
+
+            var alignmentOrigin = this.mapMarkerOffset.isEmpty
+                ? this.location
+                : GuardianMapMarkerOffsetCalculator.recoverAlignmentOrigin(
+                    this.location,
+                    this.mapMarkerOffset,
+                    this.siteHeading,
+                    planetRadiusMeters);
+            this.mapMarkerOffset = GuardianMapMarkerOffsetCalculator.calculate(
+                alignmentOrigin,
+                correctedLocation,
+                this.siteHeading,
+                planetRadiusMeters);
+            this.location = correctedLocation.clone();
+            return true;
+        }
+
+        public bool correctSiteHeading(int correctedHeading)
+        {
+            if (correctedHeading is < 0 or > 359)
+                throw new ArgumentOutOfRangeException(
+                    nameof(correctedHeading),
+                    "The site heading must be between 0 and 359 degrees.");
+            if (this.siteHeading == correctedHeading)
+                return false;
+
+            if (!this.mapMarkerOffset.isEmpty)
+                this.mapMarkerOffset = GuardianMapMarkerOffsetCalculator
+                    .rotateForHeading(
+                        this.mapMarkerOffset,
+                        this.siteHeading,
+                        correctedHeading);
+
+            this.siteHeading = correctedHeading;
+            return true;
+        }
 
         [JsonIgnore]
         public bool isRuins { get => this.type == SiteType.Alpha || this.type == SiteType.Beta || this.type == SiteType.Gamma; }
@@ -748,6 +796,29 @@ namespace SrvSurvey.game
                     obeliskGroups = new HashSet<char>(),
                 };
 
+                var mapMarkerOffset = obj["mapMarkerOffset"] as JObject;
+                if (tryReadFiniteDouble(mapMarkerOffset?["x"], out var offsetX)
+                    && tryReadFiniteDouble(mapMarkerOffset?["y"], out var offsetY))
+                    data.mapMarkerOffset = new GuardianMapMarkerOffset(
+                        offsetX,
+                        offsetY);
+
+                if (obj["localSiteId"]?.Type == JTokenType.Integer)
+                    data.localSiteId = obj["localSiteId"]!.Value<int>();
+                if (obj["catalogBodyName"]?.Type == JTokenType.String)
+                    data.catalogBodyName = obj["catalogBodyName"]!.Value<string>();
+                if (tryReadFiniteDouble(
+                    obj["distanceToArrival"],
+                    out var distanceToArrival))
+                    data.distanceToArrival = distanceToArrival;
+
+                var starPos = obj["starPos"] as JArray;
+                if (starPos?.Count >= 3
+                    && tryReadFiniteDouble(starPos[0], out var starX)
+                    && tryReadFiniteDouble(starPos[1], out var starY)
+                    && tryReadFiniteDouble(starPos[2], out var starZ))
+                    data.starPos = [starX, starY, starZ];
+
                 // read obelisk groups - in either format
                 var obeliskGroups = obj["obeliskGroups"];
                 if (obeliskGroups != null)
@@ -838,7 +909,8 @@ namespace SrvSurvey.game
                 if (rawPoi != null)
                     data.rawPoi = rawPoi.ToObject<List<SitePOI>>()!;
 
-                if (Game.settings.guardianComponentMaterials_TEST || Debugger.IsAttached)
+                if (Game.settings?.guardianComponentMaterials_TEST == true
+                    || Debugger.IsAttached)
                 {
                     var rawComponents = obj["components"] as JArray;
                     if (rawComponents != null && rawComponents.Count > 0)
@@ -883,6 +955,23 @@ namespace SrvSurvey.game
                     { "relicTowerHeading", data.relicTowerHeading },
                     { "notes", data.notes },
                 };
+
+                if (!data.mapMarkerOffset.isEmpty)
+                    obj.Add("mapMarkerOffset", new JObject
+                    {
+                        { "x", data.mapMarkerOffset.x },
+                        { "y", data.mapMarkerOffset.y },
+                    });
+                if (data.localSiteId > 0)
+                    obj.Add("localSiteId", data.localSiteId);
+                if (data.catalogBodyName != null)
+                    obj.Add("catalogBodyName", data.catalogBodyName);
+                if (data.starPos is { Length: >= 3 }
+                    && data.starPos.Take(3).All(double.IsFinite))
+                    obj.Add("starPos", new JArray(data.starPos.Take(3)));
+                if (data.distanceToArrival is { } distanceToArrival
+                    && double.IsFinite(distanceToArrival))
+                    obj.Add("distanceToArrival", distanceToArrival);
 
                 var obeliskGroups = string.Join("", data.obeliskGroups);
                 obj.Add("obeliskGroups", obeliskGroups);
@@ -930,6 +1019,19 @@ namespace SrvSurvey.game
 
                 //Game.log($"Writing: {data.bodyName} #{data.index}   ** ** ** ** {data.poiStatus.Count}");
                 obj.WriteTo(writer);
+            }
+
+            private static bool tryReadFiniteDouble(
+                JToken? token,
+                out double value)
+            {
+                value = default;
+                if (token?.Type is not JTokenType.Float
+                    and not JTokenType.Integer)
+                    return false;
+
+                value = token.Value<double>();
+                return double.IsFinite(value);
             }
         }
     }

--- a/SrvSurvey/plotters/PlotGuardians.cs
+++ b/SrvSurvey/plotters/PlotGuardians.cs
@@ -97,6 +97,15 @@ namespace SrvSurvey.plotters
             this.nextMode();
         }
 
+        public void refreshMapAlignment()
+        {
+            this.siteLocation = this.siteData.location;
+            if (game.status != null)
+                this.onStatusChange(game.status);
+            else
+                this.invalidate();
+        }
+
         protected override void onClose()
         {
             if (siteMap != null) { siteMap.Dispose(); siteMap = null; }
@@ -745,7 +754,7 @@ namespace SrvSurvey.plotters
         private void setSiteHeading(int newHeading)
         {
             Game.log($"Changing site heading from: '{siteData.siteHeading}' to: '{newHeading}'");
-            siteData.siteHeading = (int)newHeading;
+            siteData.correctSiteHeading(newHeading);
             siteData.Save();
             siteHeading = newHeading;
 
@@ -1354,9 +1363,10 @@ namespace SrvSurvey.plotters
 
                 if (foo.Value != PointF.Empty)
                 {
-                    var angle = 180 - siteData.siteHeading - foo.Value.X;
                     var dist = foo.Value.Y;
-                    var pt = (PointF)Util.rotateLine((decimal)angle, (decimal)dist);
+                    var pt = this.projectSurfaceMarker(
+                        (decimal)foo.Value.X,
+                        (decimal)dist);
                     // draw guide lines when map editor is active
                     if (this.formEditMap?.tabs.SelectedIndex == 2 && this.formEditMap?.listGroupNames.Text == foo.Key)
                     {
@@ -1445,8 +1455,7 @@ namespace SrvSurvey.plotters
                 }
 
                 // calculate render point for POI
-                var deg = 180 - siteData.siteHeading - poi.angle;
-                var pt = (PointF)Util.rotateLine(deg, poi.dist);
+                var pt = this.projectSurfaceMarker(poi.angle, poi.dist);
 
                 // render POI
                 this.drawSitePoi(g, poi, pt);
@@ -1887,8 +1896,7 @@ namespace SrvSurvey.plotters
             foreach (var poi in template.destructablePanels)
             {
                 // calculate render point for POI
-                var deg = 180 - siteData.siteHeading - poi.angle;
-                var pt = (PointF)Util.rotateLine(deg, poi.dist);
+                var pt = this.projectSurfaceMarker(poi.angle, poi.dist);
 
                 var cmp = siteData.components?.GetValueOrDefault(poi.name)?.items[0] ?? GComponent.unknown;
 
@@ -1913,6 +1921,18 @@ namespace SrvSurvey.plotters
                     }
                 });
             }
+        }
+
+        private PointF projectSurfaceMarker(decimal angle, decimal distance)
+        {
+            var point = (PointF)Util.rotateLine(
+                180 - siteData.siteHeading - angle,
+                distance);
+            var offset = GuardianMapMarkerOffsetCalculator
+                .toSurfaceCoordinates(
+                    siteData.mapMarkerOffset,
+                    siteData.siteHeading);
+            return new PointF(point.X + offset.X, point.Y + offset.Y);
         }
 
         private void drawRelicTower(Graphics g, SitePOI poi, PointF pt, SitePoiStatus poiStatus)


### PR DESCRIPTION
## Summary
- port the Guardian map-marker alignment offset from Avalonia PR Fenris159/SrvSurvey#103 into legacy SrvSurvey
- add a minimal **Guardians > Correct Map Alignment Here** command that uses the commander's current latitude/longitude as the corrected survey origin
- apply the saved offset to Guardian map POIs, group labels, component markers, hit-testing, and the live surface overlay
- read and write Avalonia-compatible top-level `mapMarkerOffset` metadata while preserving optional catalogue metadata during legacy round-trips
- retain the physical correction when the site's heading is edited

## Validation
- `dotnet test SrvSurvey.Tests/SrvSurvey.Tests.csproj --no-restore` (69 passed)
- Avalonia Guardian offset/store compatibility tests (8 passed)
- `dotnet build SrvSurvey/SrvSurvey.csproj --no-restore -c Release` (0 errors; existing nullable warnings remain)
- `dotnet format SrvSurvey.sln --no-restore --verify-no-changes --include ...`
- `git -c core.whitespace=cr-at-eol diff --check`

Fork review: Fenris159/SrvSurvey#104. Both PRs use the identical commit and branch.
