### PR TITLE
Re-apply recent commits

### DIFF
--- a/SrvSurvey/KeyChords.cs
+++ b/SrvSurvey/KeyChords.cs
@@ -441,7 +441,13 @@ namespace SrvSurvey
         {
             if (game == null) return true;
 
-            game.toggleBookmark($"#{n}", Status.here.clone());
+            var here = Status.here.clone();
+
+            // offset the location to be where rigs are deployed, vs the cockpit as usual
+            if (PlotMiniTrack.inRhino && Game.activeGame != null)
+                here = canonn.CanonnStation.adjustForCockpitOffset(Game.activeGame!.status.PlanetRadius, here, "MEV_Rhino_Rig", Game.activeGame.status.Heading);
+
+            game.toggleBookmark($"#{n}", here);
 
             return true;
         }

--- a/SrvSurvey/Main.cs
+++ b/SrvSurvey/Main.cs
@@ -602,6 +602,8 @@ namespace SrvSurvey
 
             if (game.vehicle == ActiveVehicle.MainShip)
                 this.txtVehicle.Text = Util.pascal(game.currentShip.name ?? game.currentShip.type);
+            else if (game.vehicle == ActiveVehicle.SRV && game.lastLaunchSrv != null)
+                this.txtVehicle.Text = game.lastLaunchSrv.SRVType_Localised;
             else
                 this.txtVehicle.Text = game.vehicle.ToString();
 

--- a/SrvSurvey/Settings.cs
+++ b/SrvSurvey/Settings.cs
@@ -74,7 +74,8 @@ namespace SrvSurvey
         public bool autoShowPlotBodyInfoAtSurface = false;
 
         public bool autoShowPlotMassacre_TEST = false;
-        public bool autoShowPlotMiniTrack_TEST = false;
+        public bool autoShowPlotMiniTrack = true;
+        public bool autoShowPlotMiniTrackRhino = true;        
         public bool autoShowPlotStationInfo_TEST = true;
         public bool autoShowFloatie_TEST = true;
         public bool autoShowFootCombat_TEST = false;

--- a/SrvSurvey/Util.cs
+++ b/SrvSurvey/Util.cs
@@ -640,7 +640,8 @@ static class Util
         Program.defer(() => fadeNext(form, targetOpacity, lastTick, delta));
     }
 
-    public static bool isOdyssey = Game.activeGame?.journals == null || Game.activeGame.journals.isOdyssey;
+    /// <summary> Returns true if we are operating from a Live/Odyssey journal, or false if this from a Legacy journal </summary>
+    public static bool isOdyssey = Game.activeGame?.journals == null || !Game.activeGame.journals.isLegacy;
 
     public static int GetBodyValue(Scan scan, bool cmdrMapped)
     {

--- a/SrvSurvey/forms/FormNewProject.cs
+++ b/SrvSurvey/forms/FormNewProject.cs
@@ -63,7 +63,7 @@ namespace SrvSurvey.forms
                 // pre-select if there is only one, drop the combo if there are choices
                 if (mapSites.Count == 2)
                     comboSystemSite.SelectedIndex = 1;
-                if (systemSites.Any(s => s.status != SystemSite.Status.complete))
+                if (systemSites.Any(s => s.status != SystemSite.Status.complete && s.status != SystemSite.Status.demolish))
                     comboSystemSite.DroppedDown = true;
             });
 

--- a/SrvSurvey/forms/FormPostProcess.cs
+++ b/SrvSurvey/forms/FormPostProcess.cs
@@ -266,7 +266,7 @@ namespace SrvSurvey
                         countCargoTransferredTB = countCargoTransferred;
                     }
 
-                    if (journal.isOdyssey)
+                    if (!journal.isLegacy)
                     {
                         // if Odyssey ... process all exploration events
                         SystemData? sysData = null;

--- a/SrvSurvey/forms/FormRoute.cs
+++ b/SrvSurvey/forms/FormRoute.cs
@@ -183,6 +183,8 @@ namespace SrvSurvey.forms
                 routeType = "neutron";
             else if (parts.Contains("exact-plotter"))
                 routeType = "galaxy";
+            else if (parts.Contains("fleet-carrier"))
+                routeType = "fc";
 
             Game.log($"Importing {routeType} route: '{routeId}' ...");
             lblStatus.Text = Properties.FormRouteExtras.ImportingSpansh.format(routeId);
@@ -210,6 +212,11 @@ namespace SrvSurvey.forms
                 {
                     var response = await Game.spansh.getRoute<NeutronRoute>(routeId);
                     parsedHops = response?.result?.system_jumps.Select(j => FollowRoute.Hop.from(j)).ToList()!;
+                }
+                else if (routeType == "fc")
+                {
+                    var response = await Game.spansh.getRoute<FleetCarrierRoute>(routeId);
+                    parsedHops = response?.result?.jumps.Select(j => FollowRoute.Hop.from(j)).ToList()!;
                 }
                 else
                 {

--- a/SrvSurvey/forms/FormSettings.Designer.cs
+++ b/SrvSurvey/forms/FormSettings.Designer.cs
@@ -3543,7 +3543,7 @@ namespace SrvSurvey
             checkBox38.Name = "checkBox38";
             checkBox38.Size = new Size(94, 19);
             checkBox38.TabIndex = 41;
-            checkBox38.Tag = "autoShowPlotMiniTrack_TEST";
+            checkBox38.Tag = "autoShowPlotMiniTrack";
             checkBox38.Text = "Mini trackers";
             checkBox38.UseVisualStyleBackColor = true;
             // 

--- a/SrvSurvey/game/CommanderSettings.cs
+++ b/SrvSurvey/game/CommanderSettings.cs
@@ -123,10 +123,10 @@ namespace SrvSurvey.game
             journalFiles.Find((filepath) =>
             {
                 var journal = new JournalFile(filepath);
-                if (journal.isOdyssey && !string.IsNullOrEmpty(journal.cmdrName) && !string.IsNullOrEmpty(journal.cmdrFid))
+                if (!journal.isLegacy && !string.IsNullOrEmpty(journal.cmdrName) && !string.IsNullOrEmpty(journal.cmdrFid))
                 {
                     // create and save settings for this Cmdr
-                    var cmdrSettings = CommanderSettings.Load(journal.cmdrFid, journal.isOdyssey, journal.cmdrName);
+                    var cmdrSettings = CommanderSettings.Load(journal.cmdrFid, !journal.isLegacy, journal.cmdrName);
                     cmdrSettings.Save();
                     return true;
                 }

--- a/SrvSurvey/game/FollowRoute.cs
+++ b/SrvSurvey/game/FollowRoute.cs
@@ -232,6 +232,11 @@ namespace SrvSurvey.game
                 };
             }
 
+            public static Hop from(Spansh.FleetCarrierRoute.Result.Jump jump)
+            {
+                return new Hop(jump.name, jump.id64, jump.x, jump.y, jump.z);
+            }
+
             public static implicit operator Hop(StarRef pos)
             {
                 return new Hop()

--- a/SrvSurvey/game/Game.cs
+++ b/SrvSurvey/game/Game.cs
@@ -1375,6 +1375,10 @@ namespace SrvSurvey.game
             this.fsdJumping = false;
             this.statusBodyName = null;
 
+            // update route progress?
+            if (cmdr.route?.active == true)
+                cmdr.route.setNextHop(StarRef.from(entry));
+
             this.setLocations(entry);
         }
 

--- a/SrvSurvey/game/Game.cs
+++ b/SrvSurvey/game/Game.cs
@@ -1779,7 +1779,7 @@ namespace SrvSurvey.game
             if (Game.settings.buildProjects_TEST && Game.settings.buildProjectsTrackShipCargo && cmdrColony.notHiddenProjects.Any())
                 ColonyData.publishCurrentShip(this).justDoIt();
 
-            PlotBase2.invalidate(nameof(PlotBuildCommodities));
+            PlotBase2.invalidate(nameof(PlotBuildCommodities), nameof(PlotMiniTrack));
         }
 
         private void onJournalEntry(MarketBuy entry)

--- a/SrvSurvey/game/Game.cs
+++ b/SrvSurvey/game/Game.cs
@@ -229,11 +229,6 @@ namespace SrvSurvey.game
 
             log($"Cmdr loaded: {this.Commander != null}");
 
-            // Reconstruct Inara's current-session state without uploading journal history.
-            // This must happen before live journal callbacks begin so credits and inventory
-            // have an authoritative baseline when the first new event is processed.
-            this.inara = Inara.Create(this);
-
             // now listen for changes
             this.journals.onJournalEntry += Journals_onJournalEntry;
             this.status.StatusChanged += Status_StatusChanged;
@@ -625,11 +620,7 @@ namespace SrvSurvey.game
                 log($"Game.initializeFromJournal: USING {this.Commander} (FID:{this.fid}), journals.Count:{journals?.Count}");
 
                 // set EDDN upload header
-                if (journals?.Entries.Count > 0)
-                {
-                    var gameFileHeader = (Fileheader)journals.Entries.First();
-                    EDDN.header = new UploadPayloadHeader(loadEntry.Commander, gameFileHeader.gameversion, gameFileHeader.build);
-                }
+                EDDN.header = new UploadPayloadHeader(loadEntry.Commander, journals!.fileheader!.gameversion, journals.fileheader.build);
             }
 
             // exit early if we are shutdown
@@ -644,7 +635,7 @@ namespace SrvSurvey.game
             if (loadEntry != null)
             {
                 // How much does it matter that v4-live/Horizons acts just like Odyssey?
-                this.cmdr = CommanderSettings.Load(loadEntry.FID, journals.isOdyssey, loadEntry.Commander);
+                this.cmdr = CommanderSettings.Load(loadEntry.FID, !journals.isLegacy, loadEntry.Commander);
                 this.cmdrCodex = cmdr.loadCodex();
                 this.cmdrColony = ColonyData.Load(loadEntry.FID, loadEntry.Commander);
                 // Maybe? Game.ready = true;
@@ -729,6 +720,15 @@ namespace SrvSurvey.game
 
                 if (this.status.PlanetRadius > 0 && this.status.PlanetRadius != cmdr.currentBodyRadius)
                     log($"Oops - bad systemBody ?!");
+
+                // do not upload non-Live data to Inara
+                if (!journals.isLegacy)
+                {
+                    // Reconstruct Inara's current-session state without uploading journal history.
+                    // This must happen before live journal callbacks begin so credits and inventory
+                    // have an authoritative baseline when the first new event is processed.
+                    this.inara = Inara.Create(this);
+                }
 
                 log($"Game.initializeFromJournal: system: '{cmdr.currentSystem}' (id:{cmdr.currentSystemAddress}), body: '{this.systemBody?.name}' (id:{this.systemBody?.id}, r: {Util.metersToString(this.systemBody?.radius ?? -1)})");
             }

--- a/SrvSurvey/game/GuardianSiteData.cs
+++ b/SrvSurvey/game/GuardianSiteData.cs
@@ -490,7 +490,6 @@ namespace SrvSurvey.game
             if (this.pubData == null)
             {
                 Game.log($"Why no pubData for '{this.bodyName}' / '{this.name}'? (Newly discovered Ruins?)\r\nSee: {this.filepath}");
-                if (Debugger.IsAttached) Debugger.Break();
                 return;
             }
 

--- a/SrvSurvey/game/JournalFile.cs
+++ b/SrvSurvey/game/JournalFile.cs
@@ -32,11 +32,16 @@ namespace SrvSurvey
         protected StreamReader reader;
         public readonly string filepath;
         public readonly DateTime timestamp;
+        public Fileheader? fileheader { get; private set; }
+        public LoadGame? lastLoadGame { get; private set; }
         public string? cmdrName { get; private set; }
         public string? cmdrFid { get; private set; }
-        public readonly bool isOdyssey;
-        public bool? isGameOdyssey;
-        public bool? isGameHorizons;
+        /// <summary> Returns true if this is from a Legacy journal, or false if this from a Live/Odyssey journal. Assumes NOT legacy if we don't have the Fileheader line yet. </summary>
+        public bool isLegacy => this.fileheader?.Odyssey == false;
+        /// <summary> Returns true the player paid for the Odyssey DLC </summary>
+        public bool isGameOdyssey => this.lastLoadGame?.Odyssey ?? false;
+        /// <summary> Returns true the player has the Horizons expension (which I think everyone does now) </summary>
+        public bool isGameHorizons => this.lastLoadGame?.Horizons ?? false;
 
         public bool isShutdown { get; private set; }
 
@@ -50,14 +55,6 @@ namespace SrvSurvey
             this.reader = Data.openSharedStreamReader(filepath);
 
             this.readEntries(targetFID);
-
-
-            // assume Odyssey if we don't have the Fileheader line yet.
-            this.isOdyssey = true;
-            if (this.Entries.FirstOrDefault() is Fileheader entryFileHeader)
-                this.isOdyssey = entryFileHeader.Odyssey;
-            //else
-            //    Debugger.Break(); // This happens when at the main menu before loading any cmdr
         }
 
         public void Dispose()
@@ -81,7 +78,7 @@ namespace SrvSurvey
         {
             while (this.reader?.EndOfStream == false)
             {
-                var (entry , raw)= this.readEntry();
+                var (entry, raw) = this.readEntry();
 
                 // stop early if not target cmdr
                 if (targetFID != null && entry is Commander && ((Commander)entry).FID != targetFID)
@@ -97,6 +94,18 @@ namespace SrvSurvey
             if (entry != null)
             {
                 this.Entries.Add(entry);
+
+                // keep hold of this for future reference
+                if (entry is Fileheader entryFileheader)
+                {
+                    if (this.fileheader != null)
+                    {
+                        Game.log("Why is there another Fileheader?");
+                        Debugger.Break();
+                    }
+                    this.fileheader = entryFileheader;
+                }
+
                 if (entry.@event == nameof(Shutdown) && !Program.useLastIfShutdown) this.isShutdown = true;
 
                 if (this.cmdrName == null && entry.@event == nameof(Commander))
@@ -106,11 +115,9 @@ namespace SrvSurvey
                     this.cmdrFid = commanderEntry.FID;
                 }
 
+                // keep hold of this for future reference
                 if (entry is LoadGame entryLoadGame)
-                {
-                    this.isGameOdyssey = entryLoadGame.Odyssey;
-                    this.isGameHorizons = entryLoadGame.Horizons;
-                }
+                    this.lastLoadGame = entryLoadGame;
             }
 
             return (entry, raw);
@@ -212,7 +219,7 @@ namespace SrvSurvey
                     if (finished) break;
                 }
 
-                var priorFilepath = JournalFile.getSiblingCommanderJournal(this.cmdrName, this.isOdyssey, journal.timestamp, this.cmdrFid);
+                var priorFilepath = JournalFile.getSiblingCommanderJournal(this.cmdrName, !this.isLegacy, journal.timestamp, this.cmdrFid);
                 journal = priorFilepath == null ? null : new JournalFile(priorFilepath);
             }
             ;
@@ -243,7 +250,7 @@ namespace SrvSurvey
                     if (finished) break;
                 }
 
-                priorFilepath = JournalFile.getSiblingCommanderJournal(this.cmdrName, this.isOdyssey, journal.timestamp, this.cmdrFid, searchUp);
+                priorFilepath = JournalFile.getSiblingCommanderJournal(this.cmdrName, !this.isLegacy, journal.timestamp, this.cmdrFid, searchUp);
                 if (priorFilepath != null)
                     journal = new JournalFile(priorFilepath);
 

--- a/SrvSurvey/net/CanonnStation.cs
+++ b/SrvSurvey/net/CanonnStation.cs
@@ -366,7 +366,7 @@ namespace SrvSurvey.canonn
 
             var dist = offset.dist;
             var angle = offset.angle + (decimal)shipHeading;
-            Game.log($"Adjusting landing location for: {shipType}, dist: {dist}, angle: {angle}\r\npd:{pd}, po:{offset} (alt: {Game.activeGame?.status?.Altitude})\r\n{location} =>\r\n{newLocation}");
+            Game.log($"Adjusting landing location for: {shipType}, dist: {dist}, angle: {angle}\r\nshipHeading: {shipHeading}\r\npd:{pd}, po:{offset} (alt: {Game.activeGame?.status?.Altitude})\r\n{location} =>\r\n{newLocation}");
             return newLocation;
         }
 
@@ -447,6 +447,10 @@ namespace SrvSurvey.canonn
 
             { "foot", new PointM(0d, 0d) }, // No offset applied when on foot
             { "taxi", new PointM(-0.9996653405051110150258470637, -11.913859432190865089645580760) }, // Taxi is an Adder but matching seat #2
+
+            { "MEV_Rhino", new PointM(0M, -4) },
+            // This is the offset to a rig deployed by a Rhino, not the center of a Rhino
+            { "MEV_Rhino_Rig", new PointM(0M, -7) }, 
         };
 
         public static Dictionary<string, int> mapShipSizes = new Dictionary<string, int>()

--- a/SrvSurvey/net/EDDN.cs
+++ b/SrvSurvey/net/EDDN.cs
@@ -110,8 +110,8 @@ namespace SrvSurvey.net
             // augment
             message["StarSystem"] = raw.Value<string>("System");
             message["StarPos"] = new JArray(game.systemData.starPos);
-            if (game.journals.isGameOdyssey.HasValue) message["odyssey"] = game.journals.isGameOdyssey.Value;
-            if (game.journals.isGameHorizons.HasValue) message["horizons"] = game.journals.isGameHorizons.Value;
+            if (game.journals.isGameOdyssey) message["odyssey"] = game.journals.isGameOdyssey;
+            if (game.journals.isGameHorizons) message["horizons"] = game.journals.isGameHorizons;
 
             // Only set body name/ID if status.json has a BodyName and it matches the body we are tracking ...
             if (game.status.BodyName != null && game.systemBody != null && game.status.BodyName == game.systemBody.name)
@@ -139,8 +139,8 @@ namespace SrvSurvey.net
             // augment
             message["StarSystem"] = game.systemData.name;
             message["StarPos"] = new JArray(game.systemData.starPos);
-            if (game.journals.isGameOdyssey.HasValue) message["odyssey"] = game.journals.isGameOdyssey.Value;
-            if (game.journals.isGameHorizons.HasValue) message["horizons"] = game.journals.isGameHorizons.Value;
+            if (game.journals.isGameOdyssey) message["odyssey"] = game.journals.isGameOdyssey;
+            if (game.journals.isGameHorizons) message["horizons"] = game.journals.isGameHorizons;
 
             upload(message, "https://eddn.edcd.io/schemas/approachsettlement/1").justDoIt();
         }
@@ -180,8 +180,8 @@ namespace SrvSurvey.net
             var message = new JObject(raw);
 
             // augment
-            if (game.journals.isGameOdyssey.HasValue) message["odyssey"] = game.journals.isGameOdyssey.Value;
-            if (game.journals.isGameHorizons.HasValue) message["horizons"] = game.journals.isGameHorizons.Value;
+            if (game.journals.isGameOdyssey) message["odyssey"] = game.journals.isGameOdyssey;
+            if (game.journals.isGameHorizons) message["horizons"] = game.journals.isGameHorizons;
 
             upload(message, "https://eddn.edcd.io/schemas/dockinggranted/1").justDoIt();
         }
@@ -194,8 +194,8 @@ namespace SrvSurvey.net
             var message = new JObject(raw);
 
             // augment
-            if (game.journals.isGameOdyssey.HasValue) message["odyssey"] = game.journals.isGameOdyssey.Value;
-            if (game.journals.isGameHorizons.HasValue) message["horizons"] = game.journals.isGameHorizons.Value;
+            if (game.journals.isGameOdyssey) message["odyssey"] = game.journals.isGameOdyssey;
+            if (game.journals.isGameHorizons) message["horizons"] = game.journals.isGameHorizons;
 
             upload(message, "https://eddn.edcd.io/schemas/dockingdenied/1").justDoIt();
         }
@@ -209,8 +209,8 @@ namespace SrvSurvey.net
 
             // augment
             message["StarPos"] = new JArray(game.systemData.starPos);
-            if (game.journals.isGameOdyssey.HasValue) message["odyssey"] = game.journals.isGameOdyssey.Value;
-            if (game.journals.isGameHorizons.HasValue) message["horizons"] = game.journals.isGameHorizons.Value;
+            if (game.journals.isGameOdyssey) message["odyssey"] = game.journals.isGameOdyssey;
+            if (game.journals.isGameHorizons) message["horizons"] = game.journals.isGameHorizons;
 
             upload(message, "https://eddn.edcd.io/schemas/fssallbodiesfound/1").justDoIt();
         }
@@ -228,8 +228,8 @@ namespace SrvSurvey.net
             // augment
             message["StarSystem"] = game.systemData.name;
             message["StarPos"] = new JArray(game.systemData.starPos);
-            if (game.journals.isGameOdyssey.HasValue) message["odyssey"] = game.journals.isGameOdyssey.Value;
-            if (game.journals.isGameHorizons.HasValue) message["horizons"] = game.journals.isGameHorizons.Value;
+            if (game.journals.isGameOdyssey) message["odyssey"] = game.journals.isGameOdyssey;
+            if (game.journals.isGameHorizons) message["horizons"] = game.journals.isGameHorizons;
 
             upload(message, "https://eddn.edcd.io/schemas/fssbodysignals/1").justDoIt();
         }
@@ -246,8 +246,8 @@ namespace SrvSurvey.net
 
             // augment
             message["StarPos"] = new JArray(game.systemData.starPos);
-            if (game.journals.isGameOdyssey.HasValue) message["odyssey"] = game.journals.isGameOdyssey.Value;
-            if (game.journals.isGameHorizons.HasValue) message["horizons"] = game.journals.isGameHorizons.Value;
+            if (game.journals.isGameOdyssey) message["odyssey"] = game.journals.isGameOdyssey;
+            if (game.journals.isGameHorizons) message["horizons"] = game.journals.isGameHorizons;
 
             upload(message, "https://eddn.edcd.io/schemas/fssdiscoveryscan/1").justDoIt();
         }
@@ -282,8 +282,8 @@ namespace SrvSurvey.net
             // augment
             message["StarSystem"] = game.systemData.name;
             message["StarPos"] = new JArray(game.systemData.starPos);
-            if (game.journals.isGameOdyssey.HasValue) message["odyssey"] = game.journals.isGameOdyssey.Value;
-            if (game.journals.isGameHorizons.HasValue) message["horizons"] = game.journals.isGameHorizons.Value;
+            if (game.journals.isGameOdyssey) message["odyssey"] = game.journals.isGameOdyssey;
+            if (game.journals.isGameHorizons) message["horizons"] = game.journals.isGameHorizons;
 
             upload(message, "https://eddn.edcd.io/schemas/navbeaconscan/1").justDoIt();
         }
@@ -296,8 +296,8 @@ namespace SrvSurvey.net
             var message = new JObject(raw);
 
             // augment
-            if (game.journals.isGameOdyssey.HasValue) message["odyssey"] = game.journals.isGameOdyssey.Value;
-            if (game.journals.isGameHorizons.HasValue) message["horizons"] = game.journals.isGameHorizons.Value;
+            if (game.journals.isGameOdyssey) message["odyssey"] = game.journals.isGameOdyssey;
+            if (game.journals.isGameHorizons) message["horizons"] = game.journals.isGameHorizons;
 
             upload(message, "https://eddn.edcd.io/schemas/navroute/1").justDoIt();
         }
@@ -315,8 +315,8 @@ namespace SrvSurvey.net
 
             // augment
             message["StarPos"] = new JArray(game.systemData.starPos);
-            if (game.journals.isGameOdyssey.HasValue) message["odyssey"] = game.journals.isGameOdyssey.Value;
-            if (game.journals.isGameHorizons.HasValue) message["horizons"] = game.journals.isGameHorizons.Value;
+            if (game.journals.isGameOdyssey) message["odyssey"] = game.journals.isGameOdyssey;
+            if (game.journals.isGameHorizons) message["horizons"] = game.journals.isGameHorizons;
 
             upload(message, "https://eddn.edcd.io/schemas/scanbarycentre/1").justDoIt();
         }
@@ -336,8 +336,8 @@ namespace SrvSurvey.net
 
             // augment
             message["StarPos"] = new JArray(game.systemData.starPos);
-            if (game.journals.isGameOdyssey.HasValue) message["odyssey"] = game.journals.isGameOdyssey.Value;
-            if (game.journals.isGameHorizons.HasValue) message["horizons"] = game.journals.isGameHorizons.Value;
+            if (game.journals.isGameOdyssey) message["odyssey"] = game.journals.isGameOdyssey;
+            if (game.journals.isGameHorizons) message["horizons"] = game.journals.isGameHorizons;
 
             upload(message, "https://eddn.edcd.io/schemas/journal/1").justDoIt();
         }
@@ -353,8 +353,8 @@ namespace SrvSurvey.net
             trim(message, "*_Localised", "Wanted", nameof(FSDJump.BoostUsed), nameof(FSDJump.FuelLevel), nameof(FSDJump.FuelUsed), nameof(FSDJump.JumpDist), "HappiestSystem", "HomeSystem", nameof(SystemFaction.MyReputation), "SquadronFaction");
 
             // augment
-            if (game.journals.isGameOdyssey.HasValue) message["odyssey"] = game.journals.isGameOdyssey.Value;
-            if (game.journals.isGameHorizons.HasValue) message["horizons"] = game.journals.isGameHorizons.Value;
+            if (game.journals.isGameOdyssey) message["odyssey"] = game.journals.isGameOdyssey;
+            if (game.journals.isGameHorizons) message["horizons"] = game.journals.isGameHorizons;
 
             upload(message, "https://eddn.edcd.io/schemas/journal/1").justDoIt();
         }
@@ -370,8 +370,8 @@ namespace SrvSurvey.net
             trim(message, "*_Localised", "Wanted", nameof(FSDJump.BoostUsed), nameof(FSDJump.FuelLevel), nameof(FSDJump.FuelUsed), nameof(FSDJump.JumpDist), "HappiestSystem", "HomeSystem", nameof(SystemFaction.MyReputation), "SquadronFaction");
 
             // augment
-            if (game.journals.isGameOdyssey.HasValue) message["odyssey"] = game.journals.isGameOdyssey.Value;
-            if (game.journals.isGameHorizons.HasValue) message["horizons"] = game.journals.isGameHorizons.Value;
+            if (game.journals.isGameOdyssey) message["odyssey"] = game.journals.isGameOdyssey;
+            if (game.journals.isGameHorizons) message["horizons"] = game.journals.isGameHorizons;
 
             upload(message, "https://eddn.edcd.io/schemas/journal/1").justDoIt();
         }
@@ -388,8 +388,8 @@ namespace SrvSurvey.net
 
             // augment
             message["StarPos"] = new JArray(game.systemData.starPos);
-            if (game.journals.isGameOdyssey.HasValue) message["odyssey"] = game.journals.isGameOdyssey.Value;
-            if (game.journals.isGameHorizons.HasValue) message["horizons"] = game.journals.isGameHorizons.Value;
+            if (game.journals.isGameOdyssey) message["odyssey"] = game.journals.isGameOdyssey;
+            if (game.journals.isGameHorizons) message["horizons"] = game.journals.isGameHorizons;
 
             upload(message, "https://eddn.edcd.io/schemas/journal/1").justDoIt();
         }
@@ -405,8 +405,8 @@ namespace SrvSurvey.net
             trim(message, "*_Localised", "Wanted", nameof(Location.Latitude), nameof(Location.Longitude), "HappiestSystem", "HomeSystem", nameof(SystemFaction.MyReputation), "SquadronFaction");
 
             // augment
-            if (game.journals.isGameOdyssey.HasValue) message["odyssey"] = game.journals.isGameOdyssey.Value;
-            if (game.journals.isGameHorizons.HasValue) message["horizons"] = game.journals.isGameHorizons.Value;
+            if (game.journals.isGameOdyssey) message["odyssey"] = game.journals.isGameOdyssey;
+            if (game.journals.isGameHorizons) message["horizons"] = game.journals.isGameHorizons;
 
             upload(message, "https://eddn.edcd.io/schemas/journal/1").justDoIt();
         }
@@ -424,8 +424,8 @@ namespace SrvSurvey.net
             // augment
             message["StarSystem"] = game.systemData.name;
             message["StarPos"] = new JArray(game.systemData.starPos);
-            if (game.journals.isGameOdyssey.HasValue) message["odyssey"] = game.journals.isGameOdyssey.Value;
-            if (game.journals.isGameHorizons.HasValue) message["horizons"] = game.journals.isGameHorizons.Value;
+            if (game.journals.isGameOdyssey) message["odyssey"] = game.journals.isGameOdyssey;
+            if (game.journals.isGameHorizons) message["horizons"] = game.journals.isGameHorizons;
 
             upload(message, "https://eddn.edcd.io/schemas/journal/1").justDoIt();
         }

--- a/SrvSurvey/net/Inara.cs
+++ b/SrvSurvey/net/Inara.cs
@@ -67,11 +67,11 @@ namespace SrvSurvey.net
                 if (string.IsNullOrWhiteSpace(filepath))
                     throw new InvalidOperationException("The initialized game has no journal filepath.");
 
-                var fileheader = game.journals?.Entries.FirstOrDefault() as Fileheader;
+                var fileheader = game.journals?.fileheader;
                 if (fileheader == null)
                     throw new InvalidOperationException("The initialized game journal does not start with Fileheader.");
 
-                var session = InaraSession.Create(game.cmdr, fileheader.gameversion, game.journals?.isOdyssey == true);
+                var session = InaraSession.Create(game.cmdr, fileheader.gameversion, fileheader.Odyssey);
                 if (session == null)
                     throw new InvalidOperationException("The initialized game has no commander name, Frontier ID, or game version.");
 

--- a/SrvSurvey/net/InaraEventMapper.cs
+++ b/SrvSurvey/net/InaraEventMapper.cs
@@ -246,7 +246,7 @@ namespace SrvSurvey.net
                 InMulticrew = false;
             else if (name is "JoinACrew" or "ChangeCrewRole")
                 InMulticrew = true;
-            else if (entry.Value<bool?>("Multicrew") == true)
+            else if (entry["Multicrew"]?.Type == JTokenType.Boolean && entry["Multicrew"]?.Value<bool?>() == true)
                 InMulticrew = true;
             else if (name == "LoadGame")
                 InMulticrew = false;

--- a/SrvSurvey/net/RavenColonial.cs
+++ b/SrvSurvey/net/RavenColonial.cs
@@ -842,7 +842,8 @@ public class SystemSite
     {
         plan,
         build,
-        complete
+        complete,
+        demolish,
     }
 
     public override string ToString()

--- a/SrvSurvey/net/spansh.cs
+++ b/SrvSurvey/net/spansh.cs
@@ -345,6 +345,35 @@ namespace SrvSurvey.net
             }
         }
 
+        public class FleetCarrierRoute : RouteBase
+        {
+            public Result result;
+
+            public class Result
+            {
+                public List<Jump> jumps;
+
+                public class Jump
+                {
+                    public double distance;
+                    public double distance_to_destination;
+                    public double fuel_in_tank;
+                    public double fuel_used;
+                    public long id64;
+                    public string name;
+                    public double x;
+                    public double y;
+                    public double z;
+                    // TODO: add the rest?
+
+                    public StarRef toStarRef()
+                    {
+                        return new StarRef(x, y, z, name, id64);
+                    }
+                }
+            }
+        }
+
         public async Task getClause(string genus, string species, string gas)
         {
             //Game.log($"Querying ");

--- a/SrvSurvey/plotters/PlotGrounded.cs
+++ b/SrvSurvey/plotters/PlotGrounded.cs
@@ -31,7 +31,8 @@ namespace SrvSurvey.plotters
                 && !game.status.FsdChargingJump
                 && (!Game.settings.enableGuardianSites || !PlotGuardians.allowed(game))
                 && (!Game.settings.autoShowHumanSitesTest || !PlotHumanSite.allowed(game))
-                && (game.systemBody.bioScans?.Count > 0 || game.systemBody.bookmarks?.Keys.Count(k => k[0] != '#') > 0 ||  game.cmdr.scanOne != null)
+                //&& (game.systemBody.bioScans?.Count > 0 || game.systemBody.bookmarks?.Keys.Count(k => k[0] != '#') > 0 || game.cmdr.scanOne != null)
+                && (game.systemBody.bioScans?.Count > 0 || game.systemBody.bookmarks?.Count > 0 || game.cmdr.scanOne != null)
                 && game.isMode(GameMode.SuperCruising, GameMode.Flying, GameMode.Landed, GameMode.InSrv, GameMode.OnFoot, GameMode.GlideMode, GameMode.InFighter, GameMode.CommsPanel, GameMode.RolePanel)
                 && (!Game.settings.autoHideBioPlotNoGear || game.mode != GameMode.Flying || game.status.landingGearDown)
                 ;
@@ -272,23 +273,44 @@ namespace SrvSurvey.plotters
 
                 // default range to 50m unless name matches a Genus
                 var radius = BioGenus.getRange(name);
+                if (PlotMiniTrack.inRhino && radius == 50) radius = 70;
 
                 // draw radar circles for this group, and lines
                 foreach (var tt in form.trackers[name])
                 {
                     var b = isActive ? GameColors.brushTracker : GameColors.brushTrackInactive;
                     var p = isActive ? GameColors.penTracker : GameColors.penTrackInactive;
-                    if (isActive && tt.distance < PlotTrackers.highlightDistance)
+                    if ((isActive && tt.distance < PlotTrackers.highlightDistance) || (PlotMiniTrack.inRhino && tt.distance < 5))
                     {
                         b = GameColors.brushTrackerClose;
                         p = GameColors.penTrackerClose;
                     }
 
+                    if (PlotMiniTrack.inRhino && name[0] == '#' && tt.distance < 75 && tt.distance > 10)
+                    {
+                        b = GameColors.brushExclusionDenied;
+                        p = GameColors.penExclusionDenied;
+                    }
+
                     var rect = new RectangleF((float)tt.dx - radius, (float)-tt.dy - radius, radius * 2f, radius * 2f);
                     this.drawRadarCircle(g, rect, b, p);
 
+                    // highlight mining rigs differently
+                    if (PlotMiniTrack.inRhino && name[0] == '#')
+                    {
+                        if (tt.distance < 75)
+                        {
+                            p = GameColors.penExclusionDenied;
+                            if (tt.distance < 10)
+                                p = GameColors.penRigVeryClose;
+
+                            var innerRadius = 50;
+                            rect = new RectangleF((float)tt.dx - innerRadius, (float)-tt.dy - innerRadius, innerRadius * 2f, innerRadius * 2f);
+                            this.drawRadarCircle(g, rect, b, p);
+                        }
+                    }
                     // draw an inner circle if really close
-                    if (tt.distance < PlotTrackers.highlightDistance)
+                    else if (tt.distance < PlotTrackers.highlightDistance)
                     {
                         if (game.cmdr.scanOne == null || game.cmdr.scanOne.genus == name)
                             p = GameColors.penExclusionActive;

--- a/SrvSurvey/plotters/PlotGuardians.cs
+++ b/SrvSurvey/plotters/PlotGuardians.cs
@@ -130,7 +130,7 @@ namespace SrvSurvey.plotters
              * C) Show the map
              */
 
-            if (siteData.type == GuardianSiteData.SiteType.Unknown)
+            if (siteData.type == GuardianSiteData.SiteType.Unknown || game?.Commander == null)
             {
                 // we need to know the site type before anything else
                 this.setMode(Mode.siteType);

--- a/SrvSurvey/plotters/PlotMiniTrack.cs
+++ b/SrvSurvey/plotters/PlotMiniTrack.cs
@@ -19,16 +19,14 @@ namespace SrvSurvey.plotters
 
         public static bool allowed(Game game)
         {
-            return Game.settings.autoShowPlotMiniTrack_TEST
+            return (Game.settings.autoShowPlotMiniTrack || Game.settings.autoShowPlotMiniTrackRhino)
                 // NOT suppressed by buildProjectsSuppressOtherOverlays
                 && game.systemBody != null
                 && game.status?.hasLatLong == true
-                && quickTrackers?.Count > 0
+                && (quickTrackers?.Count > 0 || inRhino)
                 && game.isMode(GameMode.SuperCruising, GameMode.Flying, GameMode.Landed, GameMode.InSrv, GameMode.OnFoot, GameMode.GlideMode, GameMode.InFighter, GameMode.CommsPanel, GameMode.RolePanel)
                 ;
         }
-
-        private static PenBrush pb = new PenBrush(C.orange, 3, LineCap.Flat);
 
         public static List<string> quickTrackers
         {
@@ -36,6 +34,8 @@ namespace SrvSurvey.plotters
         }
 
         #endregion
+
+        public static bool inRhino => Game.settings.autoShowPlotMiniTrackRhino && Game.activeGame?.vehicle == ActiveVehicle.SRV && Game.activeGame.lastLaunchSrv?.SRVType == "mev_rhino";
 
         private PlotMiniTrack(Game game, PlotDef def) : base(game, def)
         {
@@ -52,7 +52,7 @@ namespace SrvSurvey.plotters
         protected override SizeF doRender(Graphics g, TextCursor tt)
         {
             var bookmarks = game.systemBody?.bookmarks;
-            if (bookmarks == null)
+            if (bookmarks == null && !inRhino)
             {
                 remove(def);
                 return frame.Size;
@@ -60,21 +60,37 @@ namespace SrvSurvey.plotters
 
             var blockWidth = N.fiveTwo;
             var cmdr = Status.here;
+            // offset to the center of the Rhino
+            if (inRhino)
+                cmdr = canonn.CanonnStation.adjustForCockpitOffset(game.status.PlanetRadius, cmdr, "MEV_Rhino", game.status.Heading);
+
             var radius = game.status.PlanetRadius;
 
             tt.dtx = N.eight;
-            foreach (var key in quickTrackers.Order())
+            var keys = inRhino ? new [] { "#1", "#2", "#3", "#4", "#5", "#6" } : quickTrackers.Order().ToArray();
+            foreach (var key in keys)
             {
-                var list = bookmarks[key];
-                foreach (var target in list)
+                var x = tt.dtx;
+                tt.dty = N.ten;
+
+                if (inRhino && bookmarks?.ContainsKey(key) != true)
                 {
-                    var x = tt.dtx;
+                    // render an empty spot if in a Rhino and the bookmark is not set
+                    tt.draw(x, key, C.orangeDarker);
+                    var rect = new RectangleF(x + N.oneTwo, N.twoEight, N.ten * 2, N.ten * 2);
+                    g.DrawEllipse(C.Pens.orangeDarker1, rect);
+                    tt.dty = N.sixty;
+                    tt.draw(x, "--", C.orangeDarker);
+                }
+                else
+                {
+                    tt.draw(x, key);
+
+                    var target = bookmarks![key].First(); // we should only have 1 entry per quickTracker
+
                     // calculate as if a 2d plane
                     var angle2d = Util.getBearing(cmdr, target);
                     var dist2d = Util.getDistance(cmdr, target, radius);
-
-                    tt.dty = N.ten;
-                    tt.draw(x, key);
 
                     tt.dty = N.sixty;
                     tt.draw(x, Util.metersToString(dist2d));
@@ -82,13 +98,45 @@ namespace SrvSurvey.plotters
                     var deg = angle2d - game.status.Heading;
                     if (deg < 0) deg += 360;
                     if (dist2d == 0) deg += game.status.Heading;
-                    BaseWidget.renderBearingTo(g, x + N.oneTwo, N.twoEight, N.ten, (double)deg, pb.brush, pb.pen);
+                    var p = C.Pens.orange3r;
+                    var b = C.Brushes.orange;
+                    if (inRhino && dist2d < 5M)
+                    {
+                        // be blue if within pickup distance
+                        p = C.Pens.cyan3r;
+                        b = C.Brushes.cyan;
+                    }
+                    else if (inRhino && dist2d < 78M)
+                    {
+                        // be red if too close to deploy another rig
+                        p = C.Pens.red3r;
+                        b = C.Brushes.red;
+                    }
 
-                    tt.dtx = x + blockWidth;
+                    BaseWidget.renderBearingTo(g, x + N.oneTwo, N.twoEight, N.ten, (double)deg, b, p);
                 }
+
+                tt.dtx = x + blockWidth;
             }
 
-            tt.newLine(+N.four, true);
+            // draw cargo capacity
+            if (inRhino)
+            {
+                tt.newLine(+N.ten, true);
+                var used = game.cargoFile.Count;
+                tt.draw(N.ten, $"Cargo capacity: {used} of 72");
+                var w = tt.containerWidth - N.six - tt.dtx - N.six;
+                var r = new RectangleF(tt.dtx+ N.six, tt.dty, w / 72f * used, N.oneTwo);
+
+                g.FillRectangle(C.Brushes.orangeDark, r);
+
+                r.Width = w;
+                r.Inflate(1f,1f);
+                g.DrawRectangle(C.Pens.orange1, r);
+                tt.dty += N.two;
+            }
+
+            tt.newLine(+N.six, true);
             return tt.pad(0, +N.four);
         }
     }

--- a/SrvSurvey/plotters/PlotTrackers.cs
+++ b/SrvSurvey/plotters/PlotTrackers.cs
@@ -22,8 +22,8 @@ namespace SrvSurvey.plotters
             return PlotGrounded.allowed(game)
                 // same as PlotGrounded + do we have any bookmarks?
                 && (
-                    (!Game.settings.autoShowPlotMiniTrack_TEST && game.systemBody?.bookmarks?.Count > 0)
-                || (Game.settings.autoShowPlotMiniTrack_TEST && game.systemBody?.bookmarks?.Keys.Count(k => k[0] != '#') > 0)
+                    (!Game.settings.autoShowPlotMiniTrack && game.systemBody?.bookmarks?.Count > 0)
+                || (Game.settings.autoShowPlotMiniTrack && game.systemBody?.bookmarks?.Keys.Count(k => k[0] != '#') > 0)
                 );
         }
 

--- a/SrvSurvey/plotters/PlotVerticalStripe.cs
+++ b/SrvSurvey/plotters/PlotVerticalStripe.cs
@@ -165,7 +165,7 @@ namespace SrvSurvey.plotters
 
         private double getOpacity()
         {
-            if (Program.tempHideAllPlotters || !Elite.gameHasFocus)
+            if (Program.tempHideAllPlotters || !Elite.gameHasFocus || game?.Commander == null)
                 return 0;
 
             if (game.mode == GameMode.Landed)

--- a/SrvSurvey/widgets/C.cs
+++ b/SrvSurvey/widgets/C.cs
@@ -107,6 +107,7 @@ namespace SrvSurvey.widgets
 
             public static Pen red1 = red.toPen(1);
             public static Pen red2 = red.toPen(2);
+            public static Pen red3r = red.toPen(3, LineCap.Round);
 
             public static Pen redDark1 = redDark.toPen(1);
 

--- a/SrvSurvey/widgets/GameColors.cs
+++ b/SrvSurvey/widgets/GameColors.cs
@@ -254,6 +254,7 @@ namespace SrvSurvey.widgets
 
         public static Brush brushTrackerClose = new SolidBrush(Color.FromArgb(32, DarkCyan));
         public static Pen penTrackerClose = newPen(Color.FromArgb(36, Cyan), 12);
+        public static Pen penRigVeryClose = newPen(Color.FromArgb(128, C.cyan), 12);
 
         public static Pen penShipDepartFar = newPen(Color.FromArgb(64, Color.Red), 32, DashStyle.DashDotDot);
         public static Pen penShipDepartNear = newPen(Color.FromArgb(255, Color.Red), 32, DashStyle.DashDotDot);


### PR DESCRIPTION
From commit descriptions:

- Fix a cast exception when reading `Multicrew` on `Statistics` journal entries. They are not simple bool's, eg: `"Multicrew":{ "Multicrew_Time_Total":33899, "Multicrew_Gunner_Time_Total":0, "Multicrew_Fighter_Time_Total":0, "Multicrew_Credits_Total":0, "Multicrew_Fines_Total":0 }`

- add support for Spansh Fleet Carrier routes - helping to automate long FC journeys just like ship journeys
- allow for `demolish`'d sites when starting a new construction for Raven Colonial
- handle unknown Guardian sites better

- Add support for Rhino mining...
  - Adapting the mini tracker to show 6 positions for 6 rigs
  - Turning cyan when you're over a rig for collection
  - Or being red when you're too close to an existing rig